### PR TITLE
Do not specify version in Cargo manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-bot"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "kelvin-bot"
-version = "0.1.0"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
Version is managed by git tags. This change removes the version string from the `Cargo.toml` to avoid a duplicate source of truth for version information.

Maybe some day there will be a better mechanism to set the version based on Git tags/commit hash: https://github.com/rust-lang/cargo/issues/6583