### PR TITLE
📍 Add rust-toolchain.toml to pin Rust to 1.93.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.93.1"


### PR DESCRIPTION
Follows up on fe4ee1a which identified that 1.94+ causes a Send bound overflow in matrix-sdk-crypto. 