### PR TITLE
Extend host lookbehind

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.93.1"

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -138,12 +138,7 @@ impl WeeklyGathering {
         self.next_event_time() - Duration::minutes(self.config.finalize_minutes_before as i64)
     }
 
-    /// Select a host from volunteers.
-    ///
-    /// When `avoid_repeat` is false: pure random selection.
-    /// When `avoid_repeat` is true: remove recent hosts from the candidate pool
-    /// and pick randomly. If all volunteers hosted recently, fall back to the
-    /// one who hosted longest ago (oldest-first in `recent_hosts`).
+    /// Select a host from volunteers, optionally biasing against recent hosts
     pub fn select_host(
         volunteers: &HashSet<String>,
         recent_hosts: &[String],
@@ -153,7 +148,7 @@ impl WeeklyGathering {
             return None;
         }
 
-        // First try new volunteers - have not hosted recently or avoid_repeat is false
+        // First try new volunteers - i.e. have not hosted recently
         let new_volunteers: Vec<&String> = if avoid_repeat {
             volunteers.iter().filter(|v| !recent_hosts.contains(v)).collect()
         } else {

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc::Sender};
 use tokio_util::sync::CancellationToken;
 
+const HOST_LOOKBEHIND_WEEKS: usize = 4;
+
 pub struct WeeklyGatheringConfig {
     pub service_id: String,
     pub room_id: String,
@@ -274,7 +276,7 @@ impl WeeklyGathering {
         // Update recent_hosts if a host was selected
         if let Some(selected_host) = host {
             let mut state = self.state.lock().await;
-            while state.recent_hosts.len() >= 4 {
+            while state.recent_hosts.len() >= HOST_LOOKBEHIND_WEEKS {
                 state.recent_hosts.pop_front();
             }
             state.recent_hosts.push_back(selected_host);

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -238,11 +238,8 @@ impl WeeklyGathering {
 
         // Select host
         let recent_hosts: Vec<String> = state.recent_hosts.iter().cloned().collect();
-        let host = Self::select_host(
-            &state.host_volunteers,
-            &recent_hosts,
-            self.config.avoid_repeat_host,
-        );
+        let host =
+            Self::select_host(&state.host_volunteers, &recent_hosts, self.config.avoid_repeat_host);
 
         let host_display = host.as_deref().unwrap_or("No host volunteered");
 

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -138,11 +138,12 @@ impl WeeklyGathering {
         self.next_event_time() - Duration::minutes(self.config.finalize_minutes_before as i64)
     }
 
-    /// Select a host from volunteers, biasing toward the least-recently-hosted volunteer.
+    /// Select a host from volunteers.
     ///
-    /// When `avoid_repeat` is true: volunteers who haven't hosted within the look-behind
-    /// window are preferred; if all volunteers have hosted recently, the one who hosted
-    /// longest ago is chosen. Randomness is used only when multiple volunteers tie.
+    /// When `avoid_repeat` is false: pure random selection.
+    /// When `avoid_repeat` is true: remove recent hosts from the candidate pool
+    /// and pick randomly. If all volunteers hosted recently, fall back to the
+    /// one who hosted longest ago (oldest-first in `recent_hosts`).
     pub fn select_host(
         volunteers: &HashSet<String>,
         recent_hosts: &[String],
@@ -152,22 +153,20 @@ impl WeeklyGathering {
             return None;
         }
 
-        if !avoid_repeat {
-            let candidates: Vec<&String> = volunteers.iter().collect();
-            let mut rng = rand::thread_rng();
-            return candidates.choose(&mut rng).map(|s| (*s).clone());
-        }
+        // First try new volunteers - have not hosted recently or avoid_repeat is false
+        let new_volunteers: Vec<&String> = if avoid_repeat {
+            volunteers.iter().filter(|v| !recent_hosts.contains(v)).collect()
+        } else {
+            volunteers.iter().collect()
+        };
 
-        // Prefer volunteers who haven't hosted within the look-behind window
-        let unranked: Vec<&String> =
-            volunteers.iter().filter(|v| !recent_hosts.contains(v)).collect();
-        if !unranked.is_empty() {
-            let mut rng = rand::thread_rng();
-            return unranked.choose(&mut rng).map(|s| (*s).clone());
+        let mut rng = rand::thread_rng();
+
+        if !new_volunteers.is_empty() {
+            return new_volunteers.choose(&mut rng).map(|s| (*s).clone());
         }
 
         // All volunteers hosted recently — pick whoever hosted longest ago
-        // (recent_hosts is oldest-first, so iterate front to back)
         recent_hosts.iter().find(|h| volunteers.contains(*h)).cloned()
     }
 

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -138,7 +138,11 @@ impl WeeklyGathering {
         self.next_event_time() - Duration::minutes(self.config.finalize_minutes_before as i64)
     }
 
-    /// Select a host from volunteers, optionally avoiding recent hosts
+    /// Select a host from volunteers, biasing toward the least-recently-hosted volunteer.
+    ///
+    /// When `avoid_repeat` is true: volunteers who haven't hosted within the look-behind
+    /// window are preferred; if all volunteers have hosted recently, the one who hosted
+    /// longest ago is chosen. Randomness is used only when multiple volunteers tie.
     pub fn select_host(
         volunteers: &HashSet<String>,
         recent_hosts: &[String],
@@ -148,17 +152,23 @@ impl WeeklyGathering {
             return None;
         }
 
-        let candidates: Vec<&String> = if avoid_repeat {
-            let filtered: Vec<&String> =
-                volunteers.iter().filter(|v| !recent_hosts.contains(v)).collect();
-            // Fall back to all volunteers if filtering leaves no candidates
-            if filtered.is_empty() { volunteers.iter().collect() } else { filtered }
-        } else {
-            volunteers.iter().collect()
-        };
+        if !avoid_repeat {
+            let candidates: Vec<&String> = volunteers.iter().collect();
+            let mut rng = rand::thread_rng();
+            return candidates.choose(&mut rng).map(|s| (*s).clone());
+        }
 
-        let mut rng = rand::thread_rng();
-        candidates.choose(&mut rng).map(|s| (*s).clone())
+        // Prefer volunteers who haven't hosted within the look-behind window
+        let unranked: Vec<&String> =
+            volunteers.iter().filter(|v| !recent_hosts.contains(v)).collect();
+        if !unranked.is_empty() {
+            let mut rng = rand::thread_rng();
+            return unranked.choose(&mut rng).map(|s| (*s).clone());
+        }
+
+        // All volunteers hosted recently — pick whoever hosted longest ago
+        // (recent_hosts is oldest-first, so iterate front to back)
+        recent_hosts.iter().find(|h| volunteers.contains(*h)).cloned()
     }
 
     /// Post the announcement message and capture the message ID
@@ -270,13 +280,13 @@ impl WeeklyGathering {
             tracing::error!(error=%e, "failed to send finalization message");
         }
 
-        // Update recent_hosts if a host was selected (keep last 4 weeks)
+        // Update recent_hosts if a host was selected
         if let Some(selected_host) = host {
             let mut state = self.state.lock().await;
-            state.recent_hosts.push_back(selected_host);
-            while state.recent_hosts.len() > 4 {
+            while state.recent_hosts.len() >= 4 {
                 state.recent_hosts.pop_front();
             }
+            state.recent_hosts.push_back(selected_host);
         }
 
         tracing::info!(

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Datelike, Duration, Local, NaiveTime, TimeZone, Weekday};
 use rand::seq::SliceRandom;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc::Sender};
 use tokio_util::sync::CancellationToken;
@@ -42,7 +42,7 @@ struct GatheringState {
     virtual_votes: HashSet<String>,
     in_person_votes: HashSet<String>,
     host_volunteers: HashSet<String>,
-    last_host: Option<String>,
+    recent_hosts: VecDeque<String>,
 }
 
 impl Default for GatheringState {
@@ -52,7 +52,7 @@ impl Default for GatheringState {
             virtual_votes: HashSet::new(),
             in_person_votes: HashSet::new(),
             host_volunteers: HashSet::new(),
-            last_host: None,
+            recent_hosts: VecDeque::new(),
         }
     }
 }
@@ -138,10 +138,10 @@ impl WeeklyGathering {
         self.next_event_time() - Duration::minutes(self.config.finalize_minutes_before as i64)
     }
 
-    /// Select a host from volunteers, optionally avoiding the last host
+    /// Select a host from volunteers, optionally avoiding recent hosts
     pub fn select_host(
         volunteers: &HashSet<String>,
-        last_host: Option<&String>,
+        recent_hosts: &[String],
         avoid_repeat: bool,
     ) -> Option<String> {
         if volunteers.is_empty() {
@@ -150,7 +150,7 @@ impl WeeklyGathering {
 
         let candidates: Vec<&String> = if avoid_repeat {
             let filtered: Vec<&String> =
-                volunteers.iter().filter(|v| Some(*v) != last_host).collect();
+                volunteers.iter().filter(|v| !recent_hosts.contains(v)).collect();
             // Fall back to all volunteers if filtering leaves no candidates
             if filtered.is_empty() { volunteers.iter().collect() } else { filtered }
         } else {
@@ -228,9 +228,10 @@ impl WeeklyGathering {
         let in_person_count = state.in_person_votes.len();
 
         // Select host
+        let recent_hosts: Vec<String> = state.recent_hosts.iter().cloned().collect();
         let host = Self::select_host(
             &state.host_volunteers,
-            state.last_host.as_ref(),
+            &recent_hosts,
             self.config.avoid_repeat_host,
         );
 
@@ -269,10 +270,13 @@ impl WeeklyGathering {
             tracing::error!(error=%e, "failed to send finalization message");
         }
 
-        // Update last_host if a host was selected
+        // Update recent_hosts if a host was selected (keep last 4 weeks)
         if let Some(selected_host) = host {
             let mut state = self.state.lock().await;
-            state.last_host = Some(selected_host);
+            state.recent_hosts.push_back(selected_host);
+            while state.recent_hosts.len() > 4 {
+                state.recent_hosts.pop_front();
+            }
         }
 
         tracing::info!(
@@ -369,10 +373,10 @@ impl WeeklyGathering {
         (state.virtual_votes.len(), state.in_person_votes.len(), state.host_volunteers.len())
     }
 
-    /// Set the last host (for testing)
-    pub async fn set_last_host(&self, host: Option<String>) {
+    /// Set the recent hosts (for testing)
+    pub async fn set_recent_hosts(&self, hosts: Vec<String>) {
         let mut state = self.state.lock().await;
-        state.last_host = host;
+        state.recent_hosts = hosts.into_iter().collect();
     }
 
     /// Get host volunteers (for testing)

--- a/tests/unit/middleware.rs
+++ b/tests/unit/middleware.rs
@@ -1594,11 +1594,11 @@ fn test_weekly_gathering_host_selection_avoids_repeat() {
     volunteers.insert("user1".to_string());
     volunteers.insert("user2".to_string());
 
-    let last_host = "user1".to_string();
+    let recent_hosts = vec!["user1".to_string()];
 
     // Run multiple times to ensure filtering works and isn't passing by random chance
     for _ in 0..10 {
-        let result = WeeklyGathering::select_host(&volunteers, Some(&last_host), true);
+        let result = WeeklyGathering::select_host(&volunteers, &recent_hosts, true);
         assert_eq!(result, Some("user2".to_string()));
     }
 }
@@ -1609,10 +1609,52 @@ fn test_weekly_gathering_host_selection_fallback_when_only_last_host() {
     let mut volunteers = HashSet::new();
     volunteers.insert("user1".to_string());
 
-    let last_host = "user1".to_string();
+    let recent_hosts = vec!["user1".to_string()];
 
     // Should fall back to user1 when only they volunteered
-    let result = WeeklyGathering::select_host(&volunteers, Some(&last_host), true);
+    let result = WeeklyGathering::select_host(&volunteers, &recent_hosts, true);
+    assert_eq!(result, Some("user1".to_string()));
+}
+
+#[test]
+fn test_weekly_gathering_host_selection_avoids_multiple_recent() {
+    use std::collections::HashSet;
+    let mut volunteers = HashSet::new();
+    volunteers.insert("user1".to_string());
+    volunteers.insert("user2".to_string());
+    volunteers.insert("user3".to_string());
+    volunteers.insert("user4".to_string());
+    volunteers.insert("user5".to_string());
+
+    let recent_hosts = vec![
+        "user1".to_string(),
+        "user2".to_string(),
+        "user3".to_string(),
+        "user4".to_string(),
+    ];
+
+    // Only user5 is eligible; run multiple times to confirm
+    for _ in 0..10 {
+        let result = WeeklyGathering::select_host(&volunteers, &recent_hosts, true);
+        assert_eq!(result, Some("user5".to_string()));
+    }
+}
+
+#[test]
+fn test_weekly_gathering_host_selection_fallback_when_all_recent() {
+    use std::collections::HashSet;
+    let mut volunteers = HashSet::new();
+    volunteers.insert("user1".to_string());
+
+    let recent_hosts = vec![
+        "user1".to_string(),
+        "user2".to_string(),
+        "user3".to_string(),
+        "user4".to_string(),
+    ];
+
+    // Should fall back to user1 since they're the only volunteer
+    let result = WeeklyGathering::select_host(&volunteers, &recent_hosts, true);
     assert_eq!(result, Some("user1".to_string()));
 }
 
@@ -1957,7 +1999,7 @@ async fn test_weekly_gathering_finalization_avoids_repeat_host() {
     let middleware = WeeklyGathering::new(cmd_tx, config);
 
     middleware.set_announced("msg123".to_string()).await;
-    middleware.set_last_host(Some("alice".to_string())).await;
+    middleware.set_recent_hosts(vec!["alice".to_string()]).await;
 
     // Both alice and bob volunteer, but alice was last host
     middleware
@@ -1992,7 +2034,7 @@ async fn test_weekly_gathering_finalization_fallback_to_repeat_host() {
     let middleware = WeeklyGathering::new(cmd_tx, config);
 
     middleware.set_announced("msg123".to_string()).await;
-    middleware.set_last_host(Some("alice".to_string())).await;
+    middleware.set_recent_hosts(vec!["alice".to_string()]).await;
 
     // Only alice volunteers, and she was last host - should still pick her
     middleware

--- a/tests/unit/middleware.rs
+++ b/tests/unit/middleware.rs
@@ -1626,12 +1626,8 @@ fn test_weekly_gathering_host_selection_avoids_multiple_recent() {
     volunteers.insert("user4".to_string());
     volunteers.insert("user5".to_string());
 
-    let recent_hosts = vec![
-        "user1".to_string(),
-        "user2".to_string(),
-        "user3".to_string(),
-        "user4".to_string(),
-    ];
+    let recent_hosts =
+        vec!["user1".to_string(), "user2".to_string(), "user3".to_string(), "user4".to_string()];
 
     // Only user5 is eligible; run multiple times to confirm
     for _ in 0..10 {
@@ -1646,12 +1642,8 @@ fn test_weekly_gathering_host_selection_fallback_when_all_recent() {
     let mut volunteers = HashSet::new();
     volunteers.insert("user1".to_string());
 
-    let recent_hosts = vec![
-        "user1".to_string(),
-        "user2".to_string(),
-        "user3".to_string(),
-        "user4".to_string(),
-    ];
+    let recent_hosts =
+        vec!["user1".to_string(), "user2".to_string(), "user3".to_string(), "user4".to_string()];
 
     // Should pick user1 since they're the only volunteer (hosted longest ago)
     let result = WeeklyGathering::select_host(&volunteers, &recent_hosts, true);
@@ -1667,12 +1659,8 @@ fn test_weekly_gathering_host_selection_biases_least_recent() {
     volunteers.insert("user1".to_string());
     volunteers.insert("user3".to_string());
 
-    let recent_hosts = vec![
-        "user1".to_string(),
-        "user2".to_string(),
-        "user3".to_string(),
-        "user4".to_string(),
-    ];
+    let recent_hosts =
+        vec!["user1".to_string(), "user2".to_string(), "user3".to_string(), "user4".to_string()];
 
     for _ in 0..10 {
         let result = WeeklyGathering::select_host(&volunteers, &recent_hosts, true);

--- a/tests/unit/middleware.rs
+++ b/tests/unit/middleware.rs
@@ -1583,7 +1583,7 @@ async fn test_weekly_gathering_middleware_run() {
 fn test_weekly_gathering_host_selection_empty() {
     use std::collections::HashSet;
     let volunteers: HashSet<String> = HashSet::new();
-    let result = WeeklyGathering::select_host(&volunteers, None, false);
+    let result = WeeklyGathering::select_host(&volunteers, &[], false);
     assert!(result.is_none());
 }
 
@@ -1653,9 +1653,31 @@ fn test_weekly_gathering_host_selection_fallback_when_all_recent() {
         "user4".to_string(),
     ];
 
-    // Should fall back to user1 since they're the only volunteer
+    // Should pick user1 since they're the only volunteer (hosted longest ago)
     let result = WeeklyGathering::select_host(&volunteers, &recent_hosts, true);
     assert_eq!(result, Some("user1".to_string()));
+}
+
+#[test]
+fn test_weekly_gathering_host_selection_biases_least_recent() {
+    use std::collections::HashSet;
+    // user1 hosted 4 weeks ago (index 0), user3 hosted 2 weeks ago (index 2)
+    // user1 should always be chosen since they hosted least recently
+    let mut volunteers = HashSet::new();
+    volunteers.insert("user1".to_string());
+    volunteers.insert("user3".to_string());
+
+    let recent_hosts = vec![
+        "user1".to_string(),
+        "user2".to_string(),
+        "user3".to_string(),
+        "user4".to_string(),
+    ];
+
+    for _ in 0..10 {
+        let result = WeeklyGathering::select_host(&volunteers, &recent_hosts, true);
+        assert_eq!(result, Some("user1".to_string()));
+    }
 }
 
 // Functional tests for vote processing and state transitions


### PR DESCRIPTION
TODO
- [ ] Rename avoid_repeat config option? Not sure how these are set (or maybe just remove)
- [ ] Check tests are reasonable, I don't trust claude
- [ ] Merge rust-toolchain.toml separately
- [ ] Discuss state saving. It would be more flexible to store last host date per volunteer, I'm down to switch to that. I did it this way because it uses constant space for the size-bound circular buffer, but honestly we'd never be at a scale that storing a date map would be an issue.