### PR TITLE
🏘️ Prefer least-recent host for weekly gatherings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { version = "0.12", features = ["json"] }
 secrecy = { version = "0.10", features = ["serde"] }
 url = { version = "2.5", features = ["serde"] }
 humantime-serde = "1.1"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8"
 mumble-protocol-2x = "0.6"
 native-tls = "0.2"

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -114,9 +114,6 @@ pub enum MiddlewareKind {
         finalization_virtual_message: String,
         finalization_in_person_message: String,
         finalization_no_votes_message: String,
-        #[serde(default)]
-        #[serde_as(as = "DisplayFromStr")]
-        avoid_repeat_host: bool,
     },
     #[serde(other)]
     Unknown,

--- a/src/core/middleware.rs
+++ b/src/core/middleware.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use crate::core::bus::Command;
 use crate::core::config::{Config, MiddlewareKind};
 use crate::core::event::Event;
+use crate::store::PersistentStore;
 use crate::middlewares::{
     attendance_relay::{AttendanceRelay, AttendanceRelayConfig},
     chat_relay::{ChatRelay, ChatRelayConfig},
@@ -162,7 +163,6 @@ pub fn instantiate_middleware_from_config(
                 finalization_virtual_message,
                 finalization_in_person_message,
                 finalization_no_votes_message,
-                avoid_repeat_host,
             } => {
                 // Parse day_of_week string to Weekday
                 let weekday = event_day_of_week.parse::<chrono::Weekday>()
@@ -177,6 +177,9 @@ pub fn instantiate_middleware_from_config(
                         "invalid event_time format '{}' for middleware '{}'. Expected format: HH:MM (e.g., 19:00)",
                         event_time, name
                     ))?;
+
+                let store_path = config.data_directory.join(name).join("store.json");
+                let store = Arc::new(PersistentStore::load(store_path)?);
 
                 Arc::new(WeeklyGathering::new(
                     cmd_tx.clone(),
@@ -194,8 +197,8 @@ pub fn instantiate_middleware_from_config(
                         finalization_virtual_message: finalization_virtual_message.clone(),
                         finalization_in_person_message: finalization_in_person_message.clone(),
                         finalization_no_votes_message: finalization_no_votes_message.clone(),
-                        avoid_repeat_host: *avoid_repeat_host,
                     },
+                    store,
                 ))
             }
             MiddlewareKind::Unknown => {

--- a/src/core/middleware.rs
+++ b/src/core/middleware.rs
@@ -27,6 +27,17 @@ pub enum Verdict {
     Stop, // This will be used eventually.
 }
 
+/// Per-middleware context passed to every middleware constructor.
+///
+/// Bundles the shared command sender and a dedicated persistent store so that
+/// any middleware can opt into storage simply by using `ctx.store` — no
+/// changes to `instantiate_middleware_from_config` required.
+#[derive(Clone)]
+pub struct MiddlewareContext {
+    pub cmd_tx: Sender<Command>,
+    pub store: Arc<PersistentStore>,
+}
+
 #[async_trait]
 pub trait Middleware: Send + Sync {
     async fn run(&self, cancel: CancellationToken) -> Result<()>;
@@ -41,12 +52,21 @@ pub fn instantiate_middleware_from_config(
     let mut middlewares = HashMap::new();
 
     for (name, cfg) in &config.middlewares {
+        // Lazily build a MiddlewareContext for this middleware. Calling make_ctx()
+        // opens (or creates) the middleware's dedicated store file on disk. Only
+        // middlewares that actually need the context call this.
+        let make_ctx = || -> Result<MiddlewareContext> {
+            let store_path = config.data_directory.join(name).join("store.json");
+            let store = Arc::new(PersistentStore::load(store_path)?);
+            Ok(MiddlewareContext { cmd_tx: cmd_tx.clone(), store })
+        };
+
         let middleware: Arc<dyn Middleware> = match &cfg.kind {
             MiddlewareKind::Echo { command_string } => {
-                Arc::new(Echo::new(cmd_tx.clone(), command_string.clone()))
+                Arc::new(Echo::new(make_ctx()?, command_string.clone()))
             }
             MiddlewareKind::Invite { command_string, uses_allowed, expiry } => Arc::new(
-                Invite::new(cmd_tx.clone(), command_string.clone(), *uses_allowed, *expiry),
+                Invite::new(make_ctx()?, command_string.clone(), *uses_allowed, *expiry),
             ),
             MiddlewareKind::Logger {} => Arc::new(Logger {}),
             MiddlewareKind::MovieShowtimes {
@@ -75,7 +95,7 @@ pub fn instantiate_middleware_from_config(
                     ))?;
 
                 Arc::new(MovieShowtimes::new(
-                    cmd_tx.clone(),
+                    make_ctx()?,
                     service_id.clone(),
                     room_id.clone(),
                     weekday,
@@ -96,7 +116,7 @@ pub fn instantiate_middleware_from_config(
                 session_end_message,
                 session_ended_edit_message,
             } => Arc::new(AttendanceRelay::new(
-                cmd_tx.clone(),
+                make_ctx()?,
                 AttendanceRelayConfig {
                     source_service_id: source_service_id.clone(),
                     source_room_id: source_room_id.clone(),
@@ -114,7 +134,7 @@ pub fn instantiate_middleware_from_config(
                 dest_room_id,
                 prefix_tag,
             } => Arc::new(ChatRelay::new(
-                cmd_tx.clone(),
+                make_ctx()?,
                 ChatRelayConfig {
                     source_service_id: source_service_id.clone(),
                     source_room_id: source_room_id.clone(),
@@ -141,7 +161,7 @@ pub fn instantiate_middleware_from_config(
                     .collect();
 
                 Arc::new(EzStreamAnnounce::new(
-                    cmd_tx.clone(),
+                    make_ctx()?,
                     websocket_url.clone(),
                     stream_url_template.clone(),
                     start_message_template.clone(),
@@ -178,11 +198,8 @@ pub fn instantiate_middleware_from_config(
                         event_time, name
                     ))?;
 
-                let store_path = config.data_directory.join(name).join("store.json");
-                let store = Arc::new(PersistentStore::load(store_path)?);
-
                 Arc::new(WeeklyGathering::new(
-                    cmd_tx.clone(),
+                    make_ctx()?,
                     WeeklyGatheringConfig {
                         service_id: service_id.clone(),
                         room_id: room_id.clone(),
@@ -198,7 +215,6 @@ pub fn instantiate_middleware_from_config(
                         finalization_in_person_message: finalization_in_person_message.clone(),
                         finalization_no_votes_message: finalization_no_votes_message.clone(),
                     },
-                    store,
                 ))
             }
             MiddlewareKind::Unknown => {

--- a/src/core/middleware.rs
+++ b/src/core/middleware.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, sync::Arc};
 use crate::core::bus::Command;
 use crate::core::config::{Config, MiddlewareKind};
 use crate::core::event::Event;
-use crate::store::PersistentStore;
 use crate::middlewares::{
     attendance_relay::{AttendanceRelay, AttendanceRelayConfig},
     chat_relay::{ChatRelay, ChatRelayConfig},
@@ -14,6 +13,7 @@ use crate::middlewares::{
     movie_showtimes::MovieShowtimes,
     weekly_gathering::{WeeklyGathering, WeeklyGatheringConfig},
 };
+use crate::store::PersistentStore;
 use anyhow::{Result, bail};
 use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
@@ -65,9 +65,9 @@ pub fn instantiate_middleware_from_config(
             MiddlewareKind::Echo { command_string } => {
                 Arc::new(Echo::new(make_ctx()?, command_string.clone()))
             }
-            MiddlewareKind::Invite { command_string, uses_allowed, expiry } => Arc::new(
-                Invite::new(make_ctx()?, command_string.clone(), *uses_allowed, *expiry),
-            ),
+            MiddlewareKind::Invite { command_string, uses_allowed, expiry } => {
+                Arc::new(Invite::new(make_ctx()?, command_string.clone(), *uses_allowed, *expiry))
+            }
             MiddlewareKind::Logger {} => Arc::new(Logger {}),
             MiddlewareKind::MovieShowtimes {
                 service_id,

--- a/src/core/middleware.rs
+++ b/src/core/middleware.rs
@@ -56,7 +56,7 @@ pub fn instantiate_middleware_from_config(
         // opens (or creates) the middleware's dedicated store file on disk. Only
         // middlewares that actually need the context call this.
         let make_ctx = || -> Result<MiddlewareContext> {
-            let store_path = config.data_directory.join(name).join("store.json");
+            let store_path = config.data_directory.join(format!("{name}.store.json"));
             let store = Arc::new(PersistentStore::load(store_path)?);
             Ok(MiddlewareContext { cmd_tx: cmd_tx.clone(), store })
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod store;
+
 pub mod core {
     pub mod bus;
     pub mod config;

--- a/src/middlewares/attendance_relay.rs
+++ b/src/middlewares/attendance_relay.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{Middleware, Verdict},
+    middleware::{MiddlewareContext, Middleware, Verdict},
     service::ServiceId,
 };
 use anyhow::Result;
@@ -68,9 +68,9 @@ impl SessionState {
 }
 
 impl AttendanceRelay {
-    pub fn new(cmd_tx: Sender<Command>, config: AttendanceRelayConfig) -> Self {
+    pub fn new(ctx: MiddlewareContext, config: AttendanceRelayConfig) -> Self {
         Self {
-            cmd_tx,
+            cmd_tx: ctx.cmd_tx,
             source_service_id: config.source_service_id,
             source_room_id: config.source_room_id,
             dest_service_id: config.dest_service_id,

--- a/src/middlewares/attendance_relay.rs
+++ b/src/middlewares/attendance_relay.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{MiddlewareContext, Middleware, Verdict},
+    middleware::{Middleware, MiddlewareContext, Verdict},
     service::ServiceId,
 };
 use anyhow::Result;

--- a/src/middlewares/chat_relay.rs
+++ b/src/middlewares/chat_relay.rs
@@ -7,7 +7,7 @@ use tracing::{debug, error, info};
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{MiddlewareContext, Middleware, Verdict},
+    middleware::{Middleware, MiddlewareContext, Verdict},
     service::ServiceId,
 };
 

--- a/src/middlewares/chat_relay.rs
+++ b/src/middlewares/chat_relay.rs
@@ -7,7 +7,7 @@ use tracing::{debug, error, info};
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{Middleware, Verdict},
+    middleware::{MiddlewareContext, Middleware, Verdict},
     service::ServiceId,
 };
 
@@ -29,9 +29,9 @@ pub struct ChatRelay {
 }
 
 impl ChatRelay {
-    pub fn new(cmd_tx: Sender<Command>, config: ChatRelayConfig) -> Self {
+    pub fn new(ctx: MiddlewareContext, config: ChatRelayConfig) -> Self {
         Self {
-            cmd_tx,
+            cmd_tx: ctx.cmd_tx,
             source_service_id: config.source_service_id,
             source_room_id: config.source_room_id,
             dest_service_id: config.dest_service_id,

--- a/src/middlewares/echo.rs
+++ b/src/middlewares/echo.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{MiddlewareContext, Middleware, Verdict},
+    middleware::{Middleware, MiddlewareContext, Verdict},
 };
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/middlewares/echo.rs
+++ b/src/middlewares/echo.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{Middleware, Verdict},
+    middleware::{MiddlewareContext, Middleware, Verdict},
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -14,8 +14,8 @@ pub struct Echo {
 }
 
 impl Echo {
-    pub fn new(cmd_tx: Sender<Command>, command_string: String) -> Self {
-        Self { cmd_tx, command_string }
+    pub fn new(ctx: MiddlewareContext, command_string: String) -> Self {
+        Self { cmd_tx: ctx.cmd_tx, command_string }
     }
 }
 

--- a/src/middlewares/ezstream_announce.rs
+++ b/src/middlewares/ezstream_announce.rs
@@ -2,7 +2,7 @@ use crate::core::{
     bus::Command,
     config::ExponentialBackoff,
     event::Event,
-    middleware::{Middleware, Verdict},
+    middleware::{MiddlewareContext, Middleware, Verdict},
     service::ServiceId,
 };
 use anyhow::{Context, Result};
@@ -67,7 +67,7 @@ pub struct EzStreamAnnounce {
 
 impl EzStreamAnnounce {
     pub fn new(
-        cmd_tx: Sender<Command>,
+        ctx: MiddlewareContext,
         websocket_url: String,
         stream_url_template: String,
         start_message_template: String,
@@ -75,7 +75,7 @@ impl EzStreamAnnounce {
         destinations: Vec<DestinationConfig>,
     ) -> Self {
         Self {
-            cmd_tx,
+            cmd_tx: ctx.cmd_tx,
             websocket_url,
             stream_url_template,
             start_message_template,

--- a/src/middlewares/ezstream_announce.rs
+++ b/src/middlewares/ezstream_announce.rs
@@ -2,7 +2,7 @@ use crate::core::{
     bus::Command,
     config::ExponentialBackoff,
     event::Event,
-    middleware::{MiddlewareContext, Middleware, Verdict},
+    middleware::{Middleware, MiddlewareContext, Verdict},
     service::ServiceId,
 };
 use anyhow::{Context, Result};

--- a/src/middlewares/invite.rs
+++ b/src/middlewares/invite.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{Middleware, Verdict},
+    middleware::{MiddlewareContext, Middleware, Verdict},
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -18,12 +18,12 @@ pub struct Invite {
 
 impl Invite {
     pub fn new(
-        cmd_tx: Sender<Command>,
+        ctx: MiddlewareContext,
         command_string: String,
         uses_allowed: Option<u32>,
         expiry: Option<Duration>,
     ) -> Self {
-        Self { cmd_tx, command_string, uses_allowed, expiry }
+        Self { cmd_tx: ctx.cmd_tx, command_string, uses_allowed, expiry }
     }
 }
 

--- a/src/middlewares/invite.rs
+++ b/src/middlewares/invite.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{MiddlewareContext, Middleware, Verdict},
+    middleware::{Middleware, MiddlewareContext, Verdict},
 };
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/middlewares/movie_showtimes.rs
+++ b/src/middlewares/movie_showtimes.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{MiddlewareContext, Middleware, Verdict},
+    middleware::{Middleware, MiddlewareContext, Verdict},
     service::ServiceId,
 };
 use anyhow::{Context, Result};

--- a/src/middlewares/movie_showtimes.rs
+++ b/src/middlewares/movie_showtimes.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{Middleware, Verdict},
+    middleware::{MiddlewareContext, Middleware, Verdict},
     service::ServiceId,
 };
 use anyhow::{Context, Result};
@@ -106,7 +106,7 @@ pub struct MovieShowtimes {
 impl MovieShowtimes {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        cmd_tx: Sender<Command>,
+        ctx: MiddlewareContext,
         service_id: String,
         room_id: String,
         post_on_day_of_week: Weekday,
@@ -120,7 +120,7 @@ impl MovieShowtimes {
         let (query_tx, query_rx) = tokio::sync::mpsc::channel(100);
 
         Self {
-            cmd_tx,
+            cmd_tx: ctx.cmd_tx,
             service_id,
             room_id,
             post_on_day_of_week,

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{Middleware, Verdict},
+    middleware::{MiddlewareContext, Middleware, Verdict},
     service::ServiceId,
 };
 use crate::store::PersistentStore;
@@ -71,11 +71,8 @@ pub struct WeeklyGathering {
 }
 
 impl WeeklyGathering {
-    pub fn new(
-        cmd_tx: Sender<Command>,
-        config: WeeklyGatheringConfig,
-        store: Arc<PersistentStore>,
-    ) -> Self {
+    pub fn new(ctx: MiddlewareContext, config: WeeklyGatheringConfig) -> Self {
+        let MiddlewareContext { cmd_tx, store } = ctx;
         let (reaction_tx, reaction_rx) = tokio::sync::mpsc::channel(100);
 
         Self {

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -4,11 +4,12 @@ use crate::core::{
     middleware::{Middleware, Verdict},
     service::ServiceId,
 };
+use crate::store::PersistentStore;
 use anyhow::Result;
 use async_trait::async_trait;
-use chrono::{DateTime, Datelike, Duration, Local, NaiveTime, TimeZone, Weekday};
+use chrono::{DateTime, Datelike, Duration, Local, NaiveTime, TimeZone, Utc, Weekday};
 use rand::seq::SliceRandom;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc::Sender};
 use tokio_util::sync::CancellationToken;
@@ -27,7 +28,6 @@ pub struct WeeklyGatheringConfig {
     pub finalization_virtual_message: String,
     pub finalization_in_person_message: String,
     pub finalization_no_votes_message: String,
-    pub avoid_repeat_host: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -42,7 +42,6 @@ struct GatheringState {
     virtual_votes: HashSet<String>,
     in_person_votes: HashSet<String>,
     host_volunteers: HashSet<String>,
-    last_host: Option<String>,
 }
 
 impl Default for GatheringState {
@@ -52,7 +51,6 @@ impl Default for GatheringState {
             virtual_votes: HashSet::new(),
             in_person_votes: HashSet::new(),
             host_volunteers: HashSet::new(),
-            last_host: None,
         }
     }
 }
@@ -67,18 +65,24 @@ pub struct WeeklyGathering {
     cmd_tx: Sender<Command>,
     config: WeeklyGatheringConfig,
     state: Arc<Mutex<GatheringState>>,
+    store: Arc<PersistentStore>,
     reaction_tx: tokio::sync::mpsc::Sender<ReactionEvent>,
     reaction_rx: Arc<Mutex<tokio::sync::mpsc::Receiver<ReactionEvent>>>,
 }
 
 impl WeeklyGathering {
-    pub fn new(cmd_tx: Sender<Command>, config: WeeklyGatheringConfig) -> Self {
+    pub fn new(
+        cmd_tx: Sender<Command>,
+        config: WeeklyGatheringConfig,
+        store: Arc<PersistentStore>,
+    ) -> Self {
         let (reaction_tx, reaction_rx) = tokio::sync::mpsc::channel(100);
 
         Self {
             cmd_tx,
             config,
             state: Arc::new(Mutex::new(GatheringState::default())),
+            store,
             reaction_tx,
             reaction_rx: Arc::new(Mutex::new(reaction_rx)),
         }
@@ -138,24 +142,31 @@ impl WeeklyGathering {
         self.next_event_time() - Duration::minutes(self.config.finalize_minutes_before as i64)
     }
 
-    /// Select a host from volunteers, optionally avoiding the last host
+    /// Select a host from volunteers, preferring those who have hosted least recently.
+    ///
+    /// Volunteers absent from `host_history` are treated as having never hosted and are
+    /// always preferred over those with any recorded history. Among candidates with equal
+    /// last-hosted timestamps, one is chosen at random.
     pub fn select_host(
         volunteers: &HashSet<String>,
-        last_host: Option<&String>,
-        avoid_repeat: bool,
+        host_history: &HashMap<String, DateTime<Utc>>,
     ) -> Option<String> {
         if volunteers.is_empty() {
             return None;
         }
 
-        let candidates: Vec<&String> = if avoid_repeat {
-            let filtered: Vec<&String> =
-                volunteers.iter().filter(|v| Some(*v) != last_host).collect();
-            // Fall back to all volunteers if filtering leaves no candidates
-            if filtered.is_empty() { volunteers.iter().collect() } else { filtered }
-        } else {
-            volunteers.iter().collect()
-        };
+        // Treat "never hosted" as the Unix epoch so they sort before anyone who has hosted.
+        let epoch = DateTime::<Utc>::UNIX_EPOCH;
+        let min_time = volunteers
+            .iter()
+            .map(|v| host_history.get(v).copied().unwrap_or(epoch))
+            .min()
+            .expect("volunteers is non-empty");
+
+        let candidates: Vec<&String> = volunteers
+            .iter()
+            .filter(|v| host_history.get(*v).copied().unwrap_or(epoch) == min_time)
+            .collect();
 
         let mut rng = rand::thread_rng();
         candidates.choose(&mut rng).map(|s| (*s).clone())
@@ -222,17 +233,17 @@ impl WeeklyGathering {
 
     /// Post the finalization message with vote counts and host
     pub async fn post_finalization(&self) {
+        // Load host history before acquiring the state lock.
+        let mut host_history: HashMap<String, DateTime<Utc>> =
+            self.store.get("host_history").await.unwrap_or_default();
+
         let state = self.state.lock().await;
 
         let virtual_count = state.virtual_votes.len();
         let in_person_count = state.in_person_votes.len();
 
         // Select host
-        let host = Self::select_host(
-            &state.host_volunteers,
-            state.last_host.as_ref(),
-            self.config.avoid_repeat_host,
-        );
+        let host = Self::select_host(&state.host_volunteers, &host_history);
 
         let host_display = host.as_deref().unwrap_or("No host volunteered");
 
@@ -269,10 +280,12 @@ impl WeeklyGathering {
             tracing::error!(error=%e, "failed to send finalization message");
         }
 
-        // Update last_host if a host was selected
-        if let Some(selected_host) = host {
-            let mut state = self.state.lock().await;
-            state.last_host = Some(selected_host);
+        // Persist the newly selected host so future weeks prefer someone else.
+        if let Some(ref selected_host) = host {
+            host_history.insert(selected_host.clone(), Utc::now());
+            if let Err(e) = self.store.set("host_history", &host_history).await {
+                tracing::error!(error=%e, "failed to persist host history");
+            }
         }
 
         tracing::info!(
@@ -369,10 +382,12 @@ impl WeeklyGathering {
         (state.virtual_votes.len(), state.in_person_votes.len(), state.host_volunteers.len())
     }
 
-    /// Set the last host (for testing)
-    pub async fn set_last_host(&self, host: Option<String>) {
-        let mut state = self.state.lock().await;
-        state.last_host = host;
+    /// Set the host history in the backing store (for testing)
+    pub async fn set_host_history(&self, history: HashMap<String, DateTime<Utc>>) {
+        self.store
+            .set("host_history", &history)
+            .await
+            .expect("failed to set host history in store");
     }
 
     /// Get host volunteers (for testing)

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     bus::Command,
     event::{Event, EventKind},
-    middleware::{MiddlewareContext, Middleware, Verdict},
+    middleware::{Middleware, MiddlewareContext, Verdict},
     service::ServiceId,
 };
 use crate::store::PersistentStore;

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::Value;
+use std::{collections::HashMap, path::PathBuf};
+use tokio::sync::Mutex;
+
+/// A persistent, JSON-backed key-value store that saves to disk on every write.
+///
+/// Loaded once at startup; each `set` call atomically updates the in-memory map
+/// and rewrites the backing file. Use `in_memory` in tests to skip disk I/O.
+pub struct PersistentStore {
+    path: Option<PathBuf>,
+    data: Mutex<HashMap<String, Value>>,
+}
+
+impl PersistentStore {
+    /// Load the store from `path`, creating an empty store if the file does not exist.
+    pub fn load(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let data = if path.exists() {
+            let content = std::fs::read_to_string(&path)?;
+            serde_json::from_str(&content)?
+        } else {
+            HashMap::new()
+        };
+        Ok(Self { path: Some(path), data: Mutex::new(data) })
+    }
+
+    /// Create an in-memory store that never writes to disk. Useful for testing.
+    pub fn in_memory() -> Self {
+        Self { path: None, data: Mutex::new(HashMap::new()) }
+    }
+
+    /// Get the value stored under `key`, deserializing it to `T`.
+    /// Returns `None` if the key is absent or deserialization fails.
+    pub async fn get<T: DeserializeOwned>(&self, key: &str) -> Option<T> {
+        let data = self.data.lock().await;
+        data.get(key).and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+
+    /// Insert or update `key`, then persist the whole store to disk (if a path is configured).
+    pub async fn set<T: Serialize>(&self, key: &str, value: &T) -> Result<()> {
+        let serialized = serde_json::to_value(value)?;
+        let mut data = self.data.lock().await;
+        data.insert(key.to_string(), serialized);
+        if let Some(path) = &self.path {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let content = serde_json::to_string_pretty(&*data)?;
+            std::fs::write(path, content)?;
+        }
+        Ok(())
+    }
+}

--- a/tests/unit/middleware.rs
+++ b/tests/unit/middleware.rs
@@ -4,7 +4,7 @@ use kelvin_bot::core::{
     config::{Config, MiddlewareCfg, MiddlewareKind, ReconnectionConfig},
     event::{Event, EventKind, User},
     middleware::{
-        MiddlewareContext, Middleware, Verdict, build_middleware_pipeline,
+        Middleware, MiddlewareContext, Verdict, build_middleware_pipeline,
         instantiate_middleware_from_config,
     },
     service::ServiceId,
@@ -16,14 +16,14 @@ use kelvin_bot::middlewares::{
     invite::Invite,
     logger::Logger,
 };
+use kelvin_bot::store::PersistentStore;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
-use tokio_test::assert_ok;
 use tokio::sync::mpsc::Sender;
+use tokio_test::assert_ok;
 use tokio_util::sync::CancellationToken;
-use kelvin_bot::store::PersistentStore;
 
 fn make_ctx(cmd_tx: Sender<Command>) -> MiddlewareContext {
     MiddlewareContext { cmd_tx, store: Arc::new(PersistentStore::in_memory()) }
@@ -189,8 +189,10 @@ fn test_build_middleware_pipeline() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
 
     let mut all_middlewares: HashMap<String, Arc<dyn Middleware>> = HashMap::new();
-    all_middlewares
-        .insert("echo1".to_string(), Arc::new(Echo::new(make_ctx(cmd_tx.clone()), "!echo".to_string())));
+    all_middlewares.insert(
+        "echo1".to_string(),
+        Arc::new(Echo::new(make_ctx(cmd_tx.clone()), "!echo".to_string())),
+    );
     all_middlewares.insert("logger1".to_string(), Arc::new(Logger {}));
 
     let middleware_names = vec!["echo1".to_string(), "logger1".to_string()];
@@ -228,8 +230,12 @@ fn test_build_middleware_pipeline_empty() {
 #[tokio::test]
 async fn test_invite_middleware_run() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let invite =
-        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+    let invite = Invite::new(
+        make_ctx(cmd_tx),
+        "!invite".to_string(),
+        Some(1),
+        Some(Duration::from_secs(604800)),
+    );
     let cancel_token = CancellationToken::new();
 
     // Invite run should complete immediately when cancelled
@@ -241,8 +247,12 @@ async fn test_invite_middleware_run() {
 #[tokio::test]
 async fn test_invite_middleware_accepts_local_user() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let invite =
-        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+    let invite = Invite::new(
+        make_ctx(cmd_tx),
+        "!invite".to_string(),
+        Some(1),
+        Some(Duration::from_secs(604800)),
+    );
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -279,8 +289,12 @@ async fn test_invite_middleware_accepts_local_user() {
 #[tokio::test]
 async fn test_invite_middleware_rejects_non_local_user() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let invite =
-        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+    let invite = Invite::new(
+        make_ctx(cmd_tx),
+        "!invite".to_string(),
+        Some(1),
+        Some(Duration::from_secs(604800)),
+    );
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -316,8 +330,12 @@ async fn test_invite_middleware_rejects_non_local_user() {
 #[tokio::test]
 async fn test_invite_middleware_ignores_wrong_command() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let invite =
-        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+    let invite = Invite::new(
+        make_ctx(cmd_tx),
+        "!invite".to_string(),
+        Some(1),
+        Some(Duration::from_secs(604800)),
+    );
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -343,8 +361,12 @@ async fn test_invite_middleware_ignores_wrong_command() {
 #[tokio::test]
 async fn test_invite_middleware_ignores_room_messages() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let invite =
-        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+    let invite = Invite::new(
+        make_ctx(cmd_tx),
+        "!invite".to_string(),
+        Some(1),
+        Some(Duration::from_secs(604800)),
+    );
 
     let event = Event {
         service_id: ServiceId("test".to_string()),

--- a/tests/unit/middleware.rs
+++ b/tests/unit/middleware.rs
@@ -4,7 +4,8 @@ use kelvin_bot::core::{
     config::{Config, MiddlewareCfg, MiddlewareKind, ReconnectionConfig},
     event::{Event, EventKind, User},
     middleware::{
-        Middleware, Verdict, build_middleware_pipeline, instantiate_middleware_from_config,
+        MiddlewareContext, Middleware, Verdict, build_middleware_pipeline,
+        instantiate_middleware_from_config,
     },
     service::ServiceId,
 };
@@ -20,7 +21,13 @@ use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
 use tokio_test::assert_ok;
+use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
+use kelvin_bot::store::PersistentStore;
+
+fn make_ctx(cmd_tx: Sender<Command>) -> MiddlewareContext {
+    MiddlewareContext { cmd_tx, store: Arc::new(PersistentStore::in_memory()) }
+}
 
 #[test]
 fn test_verdict_copy_trait() {
@@ -64,7 +71,7 @@ fn test_logger_middleware_on_event() {
 #[tokio::test]
 async fn test_echo_middleware_with_custom_command() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let echo = Echo::new(cmd_tx, "!test".to_string());
+    let echo = Echo::new(make_ctx(cmd_tx), "!test".to_string());
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -100,7 +107,7 @@ async fn test_echo_middleware_with_custom_command() {
 #[tokio::test]
 async fn test_echo_middleware_ignores_wrong_command() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let echo = Echo::new(cmd_tx, "!echo".to_string());
+    let echo = Echo::new(make_ctx(cmd_tx), "!echo".to_string());
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -126,7 +133,7 @@ async fn test_echo_middleware_ignores_wrong_command() {
 #[tokio::test]
 async fn test_echo_middleware_ignores_self_messages() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let echo = Echo::new(cmd_tx, "!echo".to_string());
+    let echo = Echo::new(make_ctx(cmd_tx), "!echo".to_string());
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -183,7 +190,7 @@ fn test_build_middleware_pipeline() {
 
     let mut all_middlewares: HashMap<String, Arc<dyn Middleware>> = HashMap::new();
     all_middlewares
-        .insert("echo1".to_string(), Arc::new(Echo::new(cmd_tx.clone(), "!echo".to_string())));
+        .insert("echo1".to_string(), Arc::new(Echo::new(make_ctx(cmd_tx.clone()), "!echo".to_string())));
     all_middlewares.insert("logger1".to_string(), Arc::new(Logger {}));
 
     let middleware_names = vec!["echo1".to_string(), "logger1".to_string()];
@@ -222,7 +229,7 @@ fn test_build_middleware_pipeline_empty() {
 async fn test_invite_middleware_run() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
     let invite =
-        Invite::new(cmd_tx, "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
     let cancel_token = CancellationToken::new();
 
     // Invite run should complete immediately when cancelled
@@ -235,7 +242,7 @@ async fn test_invite_middleware_run() {
 async fn test_invite_middleware_accepts_local_user() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let invite =
-        Invite::new(cmd_tx, "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -273,7 +280,7 @@ async fn test_invite_middleware_accepts_local_user() {
 async fn test_invite_middleware_rejects_non_local_user() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let invite =
-        Invite::new(cmd_tx, "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -310,7 +317,7 @@ async fn test_invite_middleware_rejects_non_local_user() {
 async fn test_invite_middleware_ignores_wrong_command() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let invite =
-        Invite::new(cmd_tx, "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -337,7 +344,7 @@ async fn test_invite_middleware_ignores_wrong_command() {
 async fn test_invite_middleware_ignores_room_messages() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let invite =
-        Invite::new(cmd_tx, "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
+        Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(1), Some(Duration::from_secs(604800)));
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -364,7 +371,7 @@ async fn test_invite_middleware_ignores_room_messages() {
 async fn test_invite_middleware_with_default_config() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     // Create invite with no explicit config (will use defaults)
-    let invite = Invite::new(cmd_tx, "!invite".to_string(), None, None);
+    let invite = Invite::new(make_ctx(cmd_tx), "!invite".to_string(), None, None);
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -399,7 +406,7 @@ async fn test_invite_middleware_with_default_config() {
 async fn test_invite_middleware_with_custom_expiry() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let custom_expiry = Duration::from_secs(3600); // 1 hour
-    let invite = Invite::new(cmd_tx, "!invite".to_string(), Some(5), Some(custom_expiry));
+    let invite = Invite::new(make_ctx(cmd_tx), "!invite".to_string(), Some(5), Some(custom_expiry));
 
     let event = Event {
         service_id: ServiceId("test".to_string()),
@@ -466,7 +473,7 @@ async fn test_invite_middleware_instantiation_from_config() {
 async fn test_chat_relay_middleware_run() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
     let chat_relay = ChatRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         ChatRelayConfig {
             source_service_id: "source".to_string(),
             source_room_id: None,
@@ -487,7 +494,7 @@ async fn test_chat_relay_middleware_run() {
 async fn test_chat_relay_forwards_message_with_correct_format() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let chat_relay = ChatRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         ChatRelayConfig {
             source_service_id: "mumble".to_string(),
             source_room_id: None,
@@ -533,7 +540,7 @@ async fn test_chat_relay_forwards_message_with_correct_format() {
 async fn test_chat_relay_filters_bot_messages() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let chat_relay = ChatRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         ChatRelayConfig {
             source_service_id: "mumble".to_string(),
             source_room_id: None,
@@ -569,7 +576,7 @@ async fn test_chat_relay_filters_bot_messages() {
 async fn test_chat_relay_ignores_wrong_service() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let chat_relay = ChatRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         ChatRelayConfig {
             source_service_id: "mumble".to_string(),
             source_room_id: None,
@@ -604,7 +611,7 @@ async fn test_chat_relay_ignores_wrong_service() {
 async fn test_chat_relay_filters_by_source_room() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let chat_relay = ChatRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         ChatRelayConfig {
             source_service_id: "matrix".to_string(),
             source_room_id: Some("!general:matrix.org".to_string()),
@@ -667,7 +674,7 @@ async fn test_chat_relay_filters_by_source_room() {
 async fn test_chat_relay_ignores_direct_messages() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let chat_relay = ChatRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         ChatRelayConfig {
             source_service_id: "mumble".to_string(),
             source_room_id: None,
@@ -702,7 +709,7 @@ async fn test_chat_relay_ignores_direct_messages() {
 async fn test_chat_relay_handles_missing_display_name() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let chat_relay = ChatRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         ChatRelayConfig {
             source_service_id: "mumble".to_string(),
             source_room_id: None,
@@ -779,7 +786,7 @@ async fn test_chat_relay_instantiation_from_config() {
 async fn test_attendance_relay_middleware_run() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -802,7 +809,7 @@ async fn test_attendance_relay_middleware_run() {
 async fn test_attendance_relay_session_start() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -863,7 +870,7 @@ async fn test_attendance_relay_session_start() {
 async fn test_attendance_relay_session_update_with_edit() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -951,7 +958,7 @@ async fn test_attendance_relay_session_update_with_edit() {
 async fn test_attendance_relay_multiple_updates() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -1117,7 +1124,7 @@ async fn test_attendance_relay_multiple_updates() {
 async fn test_attendance_relay_session_end() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -1218,7 +1225,7 @@ async fn test_attendance_relay_session_end() {
 async fn test_attendance_relay_ignores_wrong_service() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -1257,7 +1264,7 @@ async fn test_attendance_relay_ignores_wrong_service() {
 async fn test_attendance_relay_ignores_non_userlist_events() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -1295,7 +1302,7 @@ async fn test_attendance_relay_ignores_non_userlist_events() {
 async fn test_attendance_relay_filters_self_user() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -1351,7 +1358,7 @@ async fn test_attendance_relay_filters_self_user() {
 async fn test_attendance_relay_filters_inactive_users() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -1407,7 +1414,7 @@ async fn test_attendance_relay_filters_inactive_users() {
 async fn test_attendance_relay_tracks_all_participants() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
     let attendance_relay = AttendanceRelay::new(
-        cmd_tx,
+        make_ctx(cmd_tx),
         AttendanceRelayConfig {
             source_service_id: "dummy".to_string(),
             source_room_id: None,
@@ -1544,9 +1551,8 @@ async fn test_attendance_relay_instantiation_from_config() {
 
 // Weekly Gathering Middleware Tests
 
-use chrono::{DateTime, NaiveTime, Utc, Weekday};
+use chrono::{NaiveTime, Utc, Weekday};
 use kelvin_bot::middlewares::weekly_gathering::{WeeklyGathering, WeeklyGatheringConfig};
-use kelvin_bot::store::PersistentStore;
 
 fn create_weekly_gathering_config() -> WeeklyGatheringConfig {
     WeeklyGatheringConfig {
@@ -1566,9 +1572,8 @@ fn create_weekly_gathering_config() -> WeeklyGatheringConfig {
     }
 }
 
-fn make_weekly_gathering(cmd_tx: tokio::sync::mpsc::Sender<Command>) -> WeeklyGathering {
-    let store = Arc::new(PersistentStore::in_memory());
-    WeeklyGathering::new(cmd_tx, create_weekly_gathering_config(), store)
+fn make_weekly_gathering(cmd_tx: Sender<Command>) -> WeeklyGathering {
+    WeeklyGathering::new(make_ctx(cmd_tx), create_weekly_gathering_config())
 }
 
 #[tokio::test]

--- a/tests/unit/middleware.rs
+++ b/tests/unit/middleware.rs
@@ -1544,8 +1544,9 @@ async fn test_attendance_relay_instantiation_from_config() {
 
 // Weekly Gathering Middleware Tests
 
-use chrono::{NaiveTime, Weekday};
+use chrono::{DateTime, NaiveTime, Utc, Weekday};
 use kelvin_bot::middlewares::weekly_gathering::{WeeklyGathering, WeeklyGatheringConfig};
+use kelvin_bot::store::PersistentStore;
 
 fn create_weekly_gathering_config() -> WeeklyGatheringConfig {
     WeeklyGatheringConfig {
@@ -1562,15 +1563,18 @@ fn create_weekly_gathering_config() -> WeeklyGatheringConfig {
         finalization_virtual_message: "This week is VIRTUAL! Host: {host}. {virtual_count} virtual, {in_person_count} in-person votes.".to_string(),
         finalization_in_person_message: "This week is IN-PERSON! Host: {host}. {virtual_count} virtual, {in_person_count} in-person votes.".to_string(),
         finalization_no_votes_message: "No votes received - gathering cancelled.".to_string(),
-        avoid_repeat_host: true,
     }
+}
+
+fn make_weekly_gathering(cmd_tx: tokio::sync::mpsc::Sender<Command>) -> WeeklyGathering {
+    let store = Arc::new(PersistentStore::in_memory());
+    WeeklyGathering::new(cmd_tx, create_weekly_gathering_config(), store)
 }
 
 #[tokio::test]
 async fn test_weekly_gathering_middleware_run() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let weekly_gathering = WeeklyGathering::new(cmd_tx, config);
+    let weekly_gathering = make_weekly_gathering(cmd_tx);
     let cancel_token = CancellationToken::new();
 
     // WeeklyGathering run should complete when cancelled
@@ -1583,36 +1587,39 @@ async fn test_weekly_gathering_middleware_run() {
 fn test_weekly_gathering_host_selection_empty() {
     use std::collections::HashSet;
     let volunteers: HashSet<String> = HashSet::new();
-    let result = WeeklyGathering::select_host(&volunteers, None, false);
+    let history = HashMap::new();
+    let result = WeeklyGathering::select_host(&volunteers, &history);
     assert!(result.is_none());
 }
 
 #[test]
-fn test_weekly_gathering_host_selection_avoids_repeat() {
+fn test_weekly_gathering_host_selection_prefers_least_recently_hosted() {
     use std::collections::HashSet;
     let mut volunteers = HashSet::new();
     volunteers.insert("user1".to_string());
     volunteers.insert("user2".to_string());
 
-    let last_host = "user1".to_string();
+    // user1 hosted recently; user2 has no history → user2 should always be chosen
+    let mut history = HashMap::new();
+    history.insert("user1".to_string(), Utc::now());
 
-    // Run multiple times to ensure filtering works and isn't passing by random chance
     for _ in 0..10 {
-        let result = WeeklyGathering::select_host(&volunteers, Some(&last_host), true);
+        let result = WeeklyGathering::select_host(&volunteers, &history);
         assert_eq!(result, Some("user2".to_string()));
     }
 }
 
 #[test]
-fn test_weekly_gathering_host_selection_fallback_when_only_last_host() {
+fn test_weekly_gathering_host_selection_only_candidate_chosen_despite_history() {
     use std::collections::HashSet;
     let mut volunteers = HashSet::new();
     volunteers.insert("user1".to_string());
 
-    let last_host = "user1".to_string();
+    // user1 is the only volunteer; must be chosen even though they hosted recently
+    let mut history = HashMap::new();
+    history.insert("user1".to_string(), Utc::now());
 
-    // Should fall back to user1 when only they volunteered
-    let result = WeeklyGathering::select_host(&volunteers, Some(&last_host), true);
+    let result = WeeklyGathering::select_host(&volunteers, &history);
     assert_eq!(result, Some("user1".to_string()));
 }
 
@@ -1621,8 +1628,7 @@ fn test_weekly_gathering_host_selection_fallback_when_only_last_host() {
 #[tokio::test]
 async fn test_weekly_gathering_ignores_reactions_when_idle() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     // Don't set phase to Announced - middleware starts in Idle
     // Process a reaction - should be ignored since we're in Idle phase
@@ -1639,8 +1645,7 @@ async fn test_weekly_gathering_ignores_reactions_when_idle() {
 #[tokio::test]
 async fn test_weekly_gathering_records_virtual_votes() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1660,8 +1665,7 @@ async fn test_weekly_gathering_records_virtual_votes() {
 #[tokio::test]
 async fn test_weekly_gathering_records_in_person_votes() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1684,8 +1688,7 @@ async fn test_weekly_gathering_records_in_person_votes() {
 #[tokio::test]
 async fn test_weekly_gathering_switching_vote_removes_previous() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1711,8 +1714,7 @@ async fn test_weekly_gathering_switching_vote_removes_previous() {
 #[tokio::test]
 async fn test_weekly_gathering_host_volunteers() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1735,8 +1737,7 @@ async fn test_weekly_gathering_host_volunteers() {
 #[tokio::test]
 async fn test_weekly_gathering_reaction_removal() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1764,8 +1765,7 @@ async fn test_weekly_gathering_reaction_removal() {
 #[tokio::test]
 async fn test_weekly_gathering_ignores_reactions_on_wrong_message() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1781,8 +1781,7 @@ async fn test_weekly_gathering_ignores_reactions_on_wrong_message() {
 #[tokio::test]
 async fn test_weekly_gathering_finalization_virtual_wins() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1823,8 +1822,7 @@ async fn test_weekly_gathering_finalization_virtual_wins() {
 #[tokio::test]
 async fn test_weekly_gathering_finalization_in_person_wins() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1865,8 +1863,7 @@ async fn test_weekly_gathering_finalization_in_person_wins() {
 #[tokio::test]
 async fn test_weekly_gathering_finalization_tie_prefers_virtual() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1903,8 +1900,7 @@ async fn test_weekly_gathering_finalization_tie_prefers_virtual() {
 #[tokio::test]
 async fn test_weekly_gathering_finalization_no_votes() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1926,8 +1922,7 @@ async fn test_weekly_gathering_finalization_no_votes() {
 #[tokio::test]
 async fn test_weekly_gathering_finalization_no_host_volunteer() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
 
@@ -1951,15 +1946,17 @@ async fn test_weekly_gathering_finalization_no_host_volunteer() {
 }
 
 #[tokio::test]
-async fn test_weekly_gathering_finalization_avoids_repeat_host() {
+async fn test_weekly_gathering_finalization_prefers_least_recently_hosted() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
-    middleware.set_last_host(Some("alice".to_string())).await;
 
-    // Both alice and bob volunteer, but alice was last host
+    // alice hosted recently; bob has no history → bob should be chosen
+    let mut history = HashMap::new();
+    history.insert("alice".to_string(), Utc::now());
+    middleware.set_host_history(history).await;
+
     middleware
         .test_process_reaction_added("msg123".to_string(), "💻".to_string(), "alice".to_string())
         .await;
@@ -1978,7 +1975,6 @@ async fn test_weekly_gathering_finalization_avoids_repeat_host() {
     assert!(cmd.is_ok());
     match cmd.unwrap() {
         Command::SendRoomMessage { body, .. } => {
-            // Should pick bob since alice was last host
             assert!(body.contains("bob"));
         }
         _ => panic!("Expected SendRoomMessage command"),
@@ -1986,15 +1982,17 @@ async fn test_weekly_gathering_finalization_avoids_repeat_host() {
 }
 
 #[tokio::test]
-async fn test_weekly_gathering_finalization_fallback_to_repeat_host() {
+async fn test_weekly_gathering_finalization_sole_volunteer_chosen_despite_history() {
     let (cmd_tx, mut cmd_rx) = create_command_channel(10);
-    let config = create_weekly_gathering_config();
-    let middleware = WeeklyGathering::new(cmd_tx, config);
+    let middleware = make_weekly_gathering(cmd_tx);
 
     middleware.set_announced("msg123".to_string()).await;
-    middleware.set_last_host(Some("alice".to_string())).await;
 
-    // Only alice volunteers, and she was last host - should still pick her
+    // alice hosted recently and is the only volunteer → must still be chosen
+    let mut history = HashMap::new();
+    history.insert("alice".to_string(), Utc::now());
+    middleware.set_host_history(history).await;
+
     middleware
         .test_process_reaction_added("msg123".to_string(), "💻".to_string(), "alice".to_string())
         .await;
@@ -2010,7 +2008,6 @@ async fn test_weekly_gathering_finalization_fallback_to_repeat_host() {
     assert!(cmd.is_ok());
     match cmd.unwrap() {
         Command::SendRoomMessage { body, .. } => {
-            // Should fall back to alice since she's the only volunteer
             assert!(body.contains("alice"));
         }
         _ => panic!("Expected SendRoomMessage command"),
@@ -2020,6 +2017,7 @@ async fn test_weekly_gathering_finalization_fallback_to_repeat_host() {
 #[tokio::test]
 async fn test_weekly_gathering_instantiation_from_config() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
+    let data_dir = TempDir::new().unwrap();
 
     let mut middlewares_map = HashMap::new();
     middlewares_map.insert(
@@ -2039,7 +2037,6 @@ async fn test_weekly_gathering_instantiation_from_config() {
                 finalization_virtual_message: "Virtual!".to_string(),
                 finalization_in_person_message: "In-person!".to_string(),
                 finalization_no_votes_message: "No votes!".to_string(),
-                avoid_repeat_host: true,
             },
         },
     );
@@ -2047,7 +2044,7 @@ async fn test_weekly_gathering_instantiation_from_config() {
     let config = Config {
         services: HashMap::new(),
         middlewares: middlewares_map,
-        data_directory: TempDir::new().unwrap().path().to_path_buf(),
+        data_directory: data_dir.path().to_path_buf(),
         reconnection: ReconnectionConfig::default(),
     };
 
@@ -2062,6 +2059,7 @@ async fn test_weekly_gathering_instantiation_from_config() {
 #[tokio::test]
 async fn test_weekly_gathering_instantiation_invalid_day_of_week() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
+    let data_dir = TempDir::new().unwrap();
 
     let mut middlewares_map = HashMap::new();
     middlewares_map.insert(
@@ -2081,7 +2079,6 @@ async fn test_weekly_gathering_instantiation_invalid_day_of_week() {
                 finalization_virtual_message: "Virtual!".to_string(),
                 finalization_in_person_message: "In-person!".to_string(),
                 finalization_no_votes_message: "No votes!".to_string(),
-                avoid_repeat_host: true,
             },
         },
     );
@@ -2089,7 +2086,7 @@ async fn test_weekly_gathering_instantiation_invalid_day_of_week() {
     let config = Config {
         services: HashMap::new(),
         middlewares: middlewares_map,
-        data_directory: TempDir::new().unwrap().path().to_path_buf(),
+        data_directory: data_dir.path().to_path_buf(),
         reconnection: ReconnectionConfig::default(),
     };
 
@@ -2102,6 +2099,7 @@ async fn test_weekly_gathering_instantiation_invalid_day_of_week() {
 #[tokio::test]
 async fn test_weekly_gathering_instantiation_invalid_time_format() {
     let (cmd_tx, _cmd_rx) = create_command_channel(10);
+    let data_dir = TempDir::new().unwrap();
 
     let mut middlewares_map = HashMap::new();
     middlewares_map.insert(
@@ -2121,7 +2119,6 @@ async fn test_weekly_gathering_instantiation_invalid_time_format() {
                 finalization_virtual_message: "Virtual!".to_string(),
                 finalization_in_person_message: "In-person!".to_string(),
                 finalization_no_votes_message: "No votes!".to_string(),
-                avoid_repeat_host: true,
             },
         },
     );
@@ -2129,7 +2126,7 @@ async fn test_weekly_gathering_instantiation_invalid_time_format() {
     let config = Config {
         services: HashMap::new(),
         middlewares: middlewares_map,
-        data_directory: TempDir::new().unwrap().path().to_path_buf(),
+        data_directory: data_dir.path().to_path_buf(),
         reconnection: ReconnectionConfig::default(),
     };
 


### PR DESCRIPTION
This change adjusts the logic for selecting a host for in-person weekly gatherings to prefer selecting the volunteer who has least-recently hosted.

It adds a common data store that middlewares can leverage for persistent storage.