### PR TITLE
🏘️ Group households for weekly gathering host rotation

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -46,6 +46,14 @@ pub enum ServiceKind {
     Unknown,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct HouseholdCfg {
+    pub name: String,
+    /// Comma-separated list of member user IDs.
+    /// Stored as a string for env-var config compatibility.
+    pub members: String,
+}
+
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
@@ -114,6 +122,8 @@ pub enum MiddlewareKind {
         finalization_virtual_message: String,
         finalization_in_person_message: String,
         finalization_no_votes_message: String,
+        #[serde(default)]
+        households: HashMap<String, HouseholdCfg>,
     },
     #[serde(other)]
     Unknown,

--- a/src/core/middleware.rs
+++ b/src/core/middleware.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::core::bus::Command;
-use crate::core::config::{Config, MiddlewareKind};
+use crate::core::config::{Config, HouseholdCfg, MiddlewareKind};
 use crate::core::event::Event;
 use crate::middlewares::{
     attendance_relay::{AttendanceRelay, AttendanceRelayConfig},
@@ -11,7 +11,7 @@ use crate::middlewares::{
     invite::Invite,
     logger::Logger,
     movie_showtimes::MovieShowtimes,
-    weekly_gathering::{WeeklyGathering, WeeklyGatheringConfig},
+    weekly_gathering::{Household, WeeklyGathering, WeeklyGatheringConfig},
 };
 use crate::store::PersistentStore;
 use anyhow::{Result, bail};
@@ -183,6 +183,7 @@ pub fn instantiate_middleware_from_config(
                 finalization_virtual_message,
                 finalization_in_person_message,
                 finalization_no_votes_message,
+                households,
             } => {
                 // Parse day_of_week string to Weekday
                 let weekday = event_day_of_week.parse::<chrono::Weekday>()
@@ -197,6 +198,19 @@ pub fn instantiate_middleware_from_config(
                         "invalid event_time format '{}' for middleware '{}'. Expected format: HH:MM (e.g., 19:00)",
                         event_time, name
                     ))?;
+
+                let runtime_households: Vec<Household> = households
+                    .values()
+                    .map(|h: &HouseholdCfg| Household {
+                        name: h.name.clone(),
+                        members: h
+                            .members
+                            .split(',')
+                            .map(|s| s.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect(),
+                    })
+                    .collect();
 
                 Arc::new(WeeklyGathering::new(
                     make_ctx()?,
@@ -214,6 +228,7 @@ pub fn instantiate_middleware_from_config(
                         finalization_virtual_message: finalization_virtual_message.clone(),
                         finalization_in_person_message: finalization_in_person_message.clone(),
                         finalization_no_votes_message: finalization_no_votes_message.clone(),
+                        households: runtime_households,
                     },
                 ))
             }

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -14,6 +14,12 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc::Sender};
 use tokio_util::sync::CancellationToken;
 
+#[derive(Debug, Clone)]
+pub struct Household {
+    pub name: String,
+    pub members: Vec<String>,
+}
+
 pub struct WeeklyGatheringConfig {
     pub service_id: String,
     pub room_id: String,
@@ -28,6 +34,7 @@ pub struct WeeklyGatheringConfig {
     pub finalization_virtual_message: String,
     pub finalization_in_person_message: String,
     pub finalization_no_votes_message: String,
+    pub households: Vec<Household>,
 }
 
 #[derive(Debug, Clone)]
@@ -144,29 +151,80 @@ impl WeeklyGathering {
     /// Volunteers absent from `host_history` are treated as having never hosted and are
     /// always preferred over those with any recorded history. Among candidates with equal
     /// last-hosted timestamps, one is chosen at random.
+    ///
+    /// Members of the same household are treated as a single candidate unit. The household's
+    /// effective last-hosted time is the maximum of all its members' times in `host_history`.
+    /// When a household member hosts, all members should have their history updated together.
+    ///
+    /// Returns `(user_id, display_name)` where `display_name` is the household name for
+    /// household volunteers, or the user_id for solo volunteers.
     pub fn select_host(
         volunteers: &HashSet<String>,
         host_history: &HashMap<String, DateTime<Utc>>,
-    ) -> Option<String> {
+        households: &[Household],
+    ) -> Option<(String, String)> {
         if volunteers.is_empty() {
             return None;
         }
 
         // Treat "never hosted" as the Unix epoch so they sort before anyone who has hosted.
         let epoch = DateTime::<Utc>::UNIX_EPOCH;
-        let min_time = volunteers
-            .iter()
-            .map(|v| host_history.get(v).copied().unwrap_or(epoch))
-            .min()
-            .expect("volunteers is non-empty");
 
-        let candidates: Vec<&String> = volunteers
-            .iter()
-            .filter(|v| host_history.get(*v).copied().unwrap_or(epoch) == min_time)
-            .collect();
+        struct CandidateUnit {
+            effective_time: DateTime<Utc>,
+            volunteering_members: Vec<String>,
+            display_name: String,
+        }
+
+        let mut seen_households: HashSet<String> = HashSet::new();
+        let mut units: Vec<CandidateUnit> = Vec::new();
+
+        for volunteer in volunteers {
+            if let Some(household) = households.iter().find(|h| h.members.contains(volunteer)) {
+                if seen_households.contains(&household.name) {
+                    continue; // Already added this household as a unit
+                }
+                seen_households.insert(household.name.clone());
+
+                // Effective time = max of all household members' history
+                let effective_time = household
+                    .members
+                    .iter()
+                    .map(|m| host_history.get(m).copied().unwrap_or(epoch))
+                    .max()
+                    .unwrap_or(epoch);
+
+                // Only the members who actually volunteered are candidates for selection
+                let volunteering_members: Vec<String> =
+                    household.members.iter().filter(|m| volunteers.contains(*m)).cloned().collect();
+
+                units.push(CandidateUnit {
+                    effective_time,
+                    volunteering_members,
+                    display_name: household.name.clone(),
+                });
+            } else {
+                // Solo volunteer — not in any household
+                units.push(CandidateUnit {
+                    effective_time: host_history.get(volunteer).copied().unwrap_or(epoch),
+                    volunteering_members: vec![volunteer.clone()],
+                    display_name: volunteer.clone(),
+                });
+            }
+        }
+
+        let min_time = units.iter().map(|u| u.effective_time).min().expect("units is non-empty");
+
+        let tied_units: Vec<&CandidateUnit> =
+            units.iter().filter(|u| u.effective_time == min_time).collect();
 
         let mut rng = rand::thread_rng();
-        candidates.choose(&mut rng).map(|s| (*s).clone())
+        let chosen_unit = tied_units.choose(&mut rng)?;
+
+        // Pick one of the volunteering members from the chosen unit at random
+        let user_id = chosen_unit.volunteering_members.choose(&mut rng)?.clone();
+
+        Some((user_id, chosen_unit.display_name.clone()))
     }
 
     /// Post the announcement message and capture the message ID
@@ -240,9 +298,13 @@ impl WeeklyGathering {
         let in_person_count = state.in_person_votes.len();
 
         // Select host
-        let host = Self::select_host(&state.host_volunteers, &host_history);
+        let host =
+            Self::select_host(&state.host_volunteers, &host_history, &self.config.households);
 
-        let host_display = host.as_deref().unwrap_or("No host volunteered");
+        let host_display = match &host {
+            Some((_, display)) => display.as_str(),
+            None => "No host volunteered",
+        };
 
         // Choose message based on vote outcome
         let template = if virtual_count == 0 && in_person_count == 0 {
@@ -278,8 +340,19 @@ impl WeeklyGathering {
         }
 
         // Persist the newly selected host so future weeks prefer someone else.
-        if let Some(ref selected_host) = host {
-            host_history.insert(selected_host.clone(), Utc::now());
+        // If the host is part of a household, update all members at the same timestamp.
+        if let Some((ref selected_user_id, _)) = host {
+            let now = Utc::now();
+            let members_to_update: Vec<String> = self
+                .config
+                .households
+                .iter()
+                .find(|h| h.members.contains(selected_user_id))
+                .map(|h| h.members.clone())
+                .unwrap_or_else(|| vec![selected_user_id.clone()]);
+            for member in &members_to_update {
+                host_history.insert(member.clone(), now);
+            }
             if let Err(e) = self.store.set("host_history", &host_history).await {
                 tracing::error!(error=%e, "failed to persist host history");
             }

--- a/src/middlewares/weekly_gathering.rs
+++ b/src/middlewares/weekly_gathering.rs
@@ -153,7 +153,8 @@ impl WeeklyGathering {
     /// last-hosted timestamps, one is chosen at random.
     ///
     /// Members of the same household are treated as a single candidate unit. The household's
-    /// effective last-hosted time is the maximum of all its members' times in `host_history`.
+    /// effective last-hosted time is the most recent time any member has hosted — so if one
+    /// member hosted last week, the whole household is considered to have hosted last week.
     /// When a household member hosts, all members should have their history updated together.
     ///
     /// Returns `(user_id, display_name)` where `display_name` is the household name for

--- a/tests/unit/middleware.rs
+++ b/tests/unit/middleware.rs
@@ -29,6 +29,10 @@ fn make_ctx(cmd_tx: Sender<Command>) -> MiddlewareContext {
     MiddlewareContext { cmd_tx, store: Arc::new(PersistentStore::in_memory()) }
 }
 
+fn make_ctx_with_store(cmd_tx: Sender<Command>, store: Arc<PersistentStore>) -> MiddlewareContext {
+    MiddlewareContext { cmd_tx, store }
+}
+
 #[test]
 fn test_verdict_copy_trait() {
     let verdict1 = Verdict::Continue;
@@ -1574,7 +1578,9 @@ async fn test_attendance_relay_instantiation_from_config() {
 // Weekly Gathering Middleware Tests
 
 use chrono::{NaiveTime, Utc, Weekday};
-use kelvin_bot::middlewares::weekly_gathering::{WeeklyGathering, WeeklyGatheringConfig};
+use kelvin_bot::middlewares::weekly_gathering::{
+    Household, WeeklyGathering, WeeklyGatheringConfig,
+};
 
 fn create_weekly_gathering_config() -> WeeklyGatheringConfig {
     WeeklyGatheringConfig {
@@ -1591,6 +1597,7 @@ fn create_weekly_gathering_config() -> WeeklyGatheringConfig {
         finalization_virtual_message: "This week is VIRTUAL! Host: {host}. {virtual_count} virtual, {in_person_count} in-person votes.".to_string(),
         finalization_in_person_message: "This week is IN-PERSON! Host: {host}. {virtual_count} virtual, {in_person_count} in-person votes.".to_string(),
         finalization_no_votes_message: "No votes received - gathering cancelled.".to_string(),
+        households: vec![],
     }
 }
 
@@ -1615,7 +1622,7 @@ fn test_weekly_gathering_host_selection_empty() {
     use std::collections::HashSet;
     let volunteers: HashSet<String> = HashSet::new();
     let history = HashMap::new();
-    let result = WeeklyGathering::select_host(&volunteers, &history);
+    let result = WeeklyGathering::select_host(&volunteers, &history, &[]);
     assert!(result.is_none());
 }
 
@@ -1631,8 +1638,8 @@ fn test_weekly_gathering_host_selection_prefers_least_recently_hosted() {
     history.insert("user1".to_string(), Utc::now());
 
     for _ in 0..10 {
-        let result = WeeklyGathering::select_host(&volunteers, &history);
-        assert_eq!(result, Some("user2".to_string()));
+        let result = WeeklyGathering::select_host(&volunteers, &history, &[]);
+        assert_eq!(result.map(|(id, _)| id), Some("user2".to_string()));
     }
 }
 
@@ -1646,8 +1653,8 @@ fn test_weekly_gathering_host_selection_only_candidate_chosen_despite_history() 
     let mut history = HashMap::new();
     history.insert("user1".to_string(), Utc::now());
 
-    let result = WeeklyGathering::select_host(&volunteers, &history);
-    assert_eq!(result, Some("user1".to_string()));
+    let result = WeeklyGathering::select_host(&volunteers, &history, &[]);
+    assert_eq!(result.map(|(id, _)| id), Some("user1".to_string()));
 }
 
 // Functional tests for vote processing and state transitions
@@ -2064,6 +2071,7 @@ async fn test_weekly_gathering_instantiation_from_config() {
                 finalization_virtual_message: "Virtual!".to_string(),
                 finalization_in_person_message: "In-person!".to_string(),
                 finalization_no_votes_message: "No votes!".to_string(),
+                households: HashMap::new(),
             },
         },
     );
@@ -2106,6 +2114,7 @@ async fn test_weekly_gathering_instantiation_invalid_day_of_week() {
                 finalization_virtual_message: "Virtual!".to_string(),
                 finalization_in_person_message: "In-person!".to_string(),
                 finalization_no_votes_message: "No votes!".to_string(),
+                households: HashMap::new(),
             },
         },
     );
@@ -2146,6 +2155,7 @@ async fn test_weekly_gathering_instantiation_invalid_time_format() {
                 finalization_virtual_message: "Virtual!".to_string(),
                 finalization_in_person_message: "In-person!".to_string(),
                 finalization_no_votes_message: "No votes!".to_string(),
+                households: HashMap::new(),
             },
         },
     );
@@ -2161,4 +2171,212 @@ async fn test_weekly_gathering_instantiation_invalid_time_format() {
     assert!(result.is_err());
     let err_msg = result.err().unwrap().to_string();
     assert!(err_msg.contains("invalid") && err_msg.contains("time"));
+}
+
+// Household grouping tests
+
+#[test]
+fn test_select_host_household_deduplication() {
+    use std::collections::HashSet;
+
+    // @hayden and @gun are the same household; @alice is solo.
+    // Give the household a very recent history so @alice always wins.
+    let households = vec![Household {
+        name: "Hayden and Gunnar".to_string(),
+        members: vec!["@hayden".to_string(), "@gun".to_string()],
+    }];
+
+    let mut volunteers = HashSet::new();
+    volunteers.insert("@hayden".to_string());
+    volunteers.insert("@gun".to_string());
+    volunteers.insert("@alice".to_string());
+
+    let mut history = HashMap::new();
+    history.insert("@hayden".to_string(), Utc::now());
+    history.insert("@gun".to_string(), Utc::now());
+    // @alice has no history → epoch → always preferred
+
+    for _ in 0..10 {
+        let result = WeeklyGathering::select_host(&volunteers, &history, &households);
+        assert_eq!(result.map(|(id, _)| id), Some("@alice".to_string()));
+    }
+}
+
+#[test]
+fn test_select_host_household_effective_time() {
+    use std::collections::HashSet;
+
+    // Household: [@hayden, @gun]. @gun hosted 1 day ago.
+    // @alice hosted 2 days ago → @alice is older, so @alice should be preferred.
+    let households = vec![Household {
+        name: "Hayden and Gunnar".to_string(),
+        members: vec!["@hayden".to_string(), "@gun".to_string()],
+    }];
+
+    let mut volunteers = HashSet::new();
+    volunteers.insert("@hayden".to_string());
+    volunteers.insert("@alice".to_string());
+
+    let mut history = HashMap::new();
+    let one_day_ago = Utc::now() - chrono::Duration::days(1);
+    let two_days_ago = Utc::now() - chrono::Duration::days(2);
+    history.insert("@gun".to_string(), one_day_ago); // household effective time = 1 day ago
+    history.insert("@alice".to_string(), two_days_ago); // alice = 2 days ago → older → preferred
+
+    for _ in 0..10 {
+        let result = WeeklyGathering::select_host(&volunteers, &history, &households);
+        assert_eq!(result.map(|(id, _)| id), Some("@alice".to_string()));
+    }
+}
+
+#[test]
+fn test_select_host_household_display_name() {
+    use std::collections::HashSet;
+
+    let households = vec![Household {
+        name: "Hayden and Gunnar".to_string(),
+        members: vec!["@hayden".to_string(), "@gun".to_string()],
+    }];
+
+    let mut volunteers = HashSet::new();
+    volunteers.insert("@hayden".to_string());
+
+    let history = HashMap::new();
+
+    let result = WeeklyGathering::select_host(&volunteers, &history, &households);
+    assert!(result.is_some());
+    let (user_id, display_name) = result.unwrap();
+    assert_eq!(user_id, "@hayden");
+    assert_eq!(display_name, "Hayden and Gunnar");
+}
+
+#[tokio::test]
+async fn test_finalization_propagates_history_to_all_household_members() {
+    let (cmd_tx, mut cmd_rx) = create_command_channel(10);
+    let store = Arc::new(PersistentStore::in_memory());
+
+    let mut config = create_weekly_gathering_config();
+    config.households = vec![Household {
+        name: "Hayden and Gunnar".to_string(),
+        members: vec!["@hayden".to_string(), "@gun".to_string()],
+    }];
+
+    let middleware = WeeklyGathering::new(make_ctx_with_store(cmd_tx, store.clone()), config);
+
+    middleware.set_announced("msg123".to_string()).await;
+
+    // @hayden is the only host volunteer (but @gun is in the same household)
+    middleware
+        .test_process_reaction_added("msg123".to_string(), "💻".to_string(), "@hayden".to_string())
+        .await;
+    middleware
+        .test_process_reaction_added("msg123".to_string(), "🙋".to_string(), "@hayden".to_string())
+        .await;
+
+    middleware.post_finalization().await;
+
+    // Drain the SendRoomMessage command
+    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    let _ = cmd_rx.try_recv();
+
+    // Both household members should have the same timestamp in host_history
+    let host_history: HashMap<String, chrono::DateTime<Utc>> =
+        store.get("host_history").await.expect("host history should be persisted");
+
+    assert!(host_history.contains_key("@hayden"), "@hayden should be in host history");
+    assert!(host_history.contains_key("@gun"), "@gun should be in host history (same household)");
+    assert_eq!(
+        host_history["@hayden"], host_history["@gun"],
+        "both household members should have the same timestamp"
+    );
+}
+
+#[tokio::test]
+async fn test_finalization_household_display_name_in_message() {
+    let (cmd_tx, mut cmd_rx) = create_command_channel(10);
+
+    let mut config = create_weekly_gathering_config();
+    config.households = vec![Household {
+        name: "Hayden and Gunnar".to_string(),
+        members: vec!["@hayden".to_string(), "@gun".to_string()],
+    }];
+
+    let middleware = WeeklyGathering::new(make_ctx(cmd_tx), config);
+
+    middleware.set_announced("msg123".to_string()).await;
+
+    middleware
+        .test_process_reaction_added("msg123".to_string(), "💻".to_string(), "@hayden".to_string())
+        .await;
+    middleware
+        .test_process_reaction_added("msg123".to_string(), "🙋".to_string(), "@hayden".to_string())
+        .await;
+
+    middleware.post_finalization().await;
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+    let cmd = cmd_rx.try_recv();
+    assert!(cmd.is_ok());
+    match cmd.unwrap() {
+        Command::SendRoomMessage { body, .. } => {
+            assert!(
+                body.contains("Hayden and Gunnar"),
+                "message should use household display name, got: {body}"
+            );
+        }
+        _ => panic!("Expected SendRoomMessage command"),
+    }
+}
+
+#[tokio::test]
+async fn test_weekly_gathering_instantiation_with_households() {
+    let (cmd_tx, _cmd_rx) = create_command_channel(10);
+    let data_dir = TempDir::new().unwrap();
+
+    use kelvin_bot::core::config::HouseholdCfg;
+
+    let mut middlewares_map = HashMap::new();
+    middlewares_map.insert(
+        "test_weekly_gathering".to_string(),
+        MiddlewareCfg {
+            kind: MiddlewareKind::WeeklyGathering {
+                service_id: "matrix".to_string(),
+                room_id: "!gathering:matrix.org".to_string(),
+                event_day_of_week: "Saturday".to_string(),
+                event_time: "19:00".to_string(),
+                announce_minutes_before: 4320,
+                finalize_minutes_before: 120,
+                reaction_virtual: "💻".to_string(),
+                reaction_in_person: "🏠".to_string(),
+                reaction_host: "🙋".to_string(),
+                announcement_message: "Weekly poll!".to_string(),
+                finalization_virtual_message: "Virtual!".to_string(),
+                finalization_in_person_message: "In-person!".to_string(),
+                finalization_no_votes_message: "No votes!".to_string(),
+                households: {
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "h1".to_string(),
+                        HouseholdCfg {
+                            name: "Hayden and Gunnar".to_string(),
+                            members: "@hayden:warmitup.chat,@gun:warmitup.chat".to_string(),
+                        },
+                    );
+                    m
+                },
+            },
+        },
+    );
+
+    let config = Config {
+        services: HashMap::new(),
+        middlewares: middlewares_map,
+        data_directory: data_dir.path().to_path_buf(),
+        reconnection: ReconnectionConfig::default(),
+    };
+
+    let result = instantiate_middleware_from_config(&config, &cmd_tx);
+    assert_ok!(&result);
+    assert_eq!(result.unwrap().len(), 1);
 }


### PR DESCRIPTION
Members of the same household are treated as a single candidate unit during host selection. If any member hosted recently, the whole household is considered recently hosted, and when a household member is selected all members receive the same history timestamp.