### PR TITLE
🐛 Install procps in runtime image to fix healthcheck (fixes #43)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM debian:bookworm-slim
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user


### PR DESCRIPTION
pgrep is provided by procps, which was absent from the debian:bookworm-slim runtime stage, causing the healthcheck to fail on startup.