### PR TITLE
✨ Relay images from Matrix to Mumble via chat_relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,10 +361,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1007,6 +1019,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1689,6 +1710,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "imbl"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,11 +1935,13 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "config",
  "dotenvy",
  "futures",
  "humantime-serde",
+ "image",
  "matrix-sdk",
  "mumble-protocol-2x",
  "native-tls",
@@ -2428,6 +2477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2439,6 +2489,16 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -2808,6 +2868,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,6 +3061,18 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -3864,6 +3949,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -5347,4 +5438,19 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ humantime-serde = "1.1"
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8"
 mumble-protocol-2x = "0.6"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+base64 = "0.22"
 native-tls = "0.2"
 tokio-native-tls = "0.3"
 futures = "0.3"

--- a/src/core/bus.rs
+++ b/src/core/bus.rs
@@ -52,6 +52,14 @@ pub enum Command {
         event_id: String,
         key: String,
     },
+    SendRoomImage {
+        service_id: ServiceId,
+        room_id: String,
+        caption: String,
+        source_url: String,
+        thumbnail_data: Vec<u8>,
+        thumbnail_mimetype: String,
+    },
 }
 
 // Implement Debug manually since oneshot::Sender doesn't implement Clone
@@ -110,6 +118,12 @@ impl std::fmt::Debug for Command {
                 .field("room_id", room_id)
                 .field("event_id", event_id)
                 .field("key", key)
+                .finish(),
+            Command::SendRoomImage { service_id, room_id, caption, .. } => f
+                .debug_struct("SendRoomImage")
+                .field("service_id", service_id)
+                .field("room_id", room_id)
+                .field("caption", caption)
                 .finish(),
         }
     }
@@ -315,6 +329,7 @@ impl Bus {
                         Command::EditMessage { service_id, .. } => service_id.clone(),
                         Command::GenerateInviteToken { service_id, .. } => service_id.clone(),
                         Command::AddReaction { service_id, .. } => service_id.clone(),
+                        Command::SendRoomImage { service_id, .. } => service_id.clone(),
                     };
 
                     // Dispatch command to appropriate service

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -97,6 +97,12 @@ pub enum MiddlewareKind {
         dest_service_id: String,
         dest_room_id: String,
         prefix_tag: String,
+        #[serde(default = "default_thumbnail_max_width")]
+        thumbnail_max_width: u32,
+        #[serde(default = "default_thumbnail_max_height")]
+        thumbnail_max_height: u32,
+        #[serde(default = "default_thumbnail_jpeg_quality")]
+        thumbnail_jpeg_quality: u8,
     },
     EzStreamAnnounce {
         websocket_url: String,
@@ -142,6 +148,18 @@ pub struct Config {
 
 fn default_data_directory() -> PathBuf {
     PathBuf::from("./data")
+}
+
+fn default_thumbnail_max_width() -> u32 {
+    480
+}
+
+fn default_thumbnail_max_height() -> u32 {
+    360
+}
+
+fn default_thumbnail_jpeg_quality() -> u8 {
+    75
 }
 
 // Reconnection configuration with exponential backoff

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -57,6 +57,20 @@ pub enum EventKind {
         sender_id: String,
         is_self: bool,
     },
+    RoomImage {
+        room_id: String,
+        sender_id: String,
+        sender_display_name: Option<String>,
+        is_self: bool,
+        is_local_user: bool,
+        body: String,
+        source_url: String,
+        mimetype: Option<String>,
+        /// Pre-fetched raw image bytes. Populated by services that have
+        /// authenticated access to the media (e.g. Matrix). When present,
+        /// the relay uses these directly instead of re-fetching via source_url.
+        image_data: Option<Vec<u8>>,
+    },
 }
 
 impl fmt::Display for Event {
@@ -77,6 +91,9 @@ impl fmt::Display for Event {
             }
             EventKind::ReactionRemoved { room_id, sender_id, event_id, .. } => {
                 write!(f, "[React-] {room_id}: {sender_id} removed reaction {event_id}")
+            }
+            EventKind::RoomImage { room_id, body, .. } => {
+                write!(f, "[IMG] {room_id}: {body}")
             }
         }
     }

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
@@ -69,7 +69,7 @@ pub enum EventKind {
         /// Pre-fetched raw image bytes. Populated by services that have
         /// authenticated access to the media (e.g. Matrix). When present,
         /// the relay uses these directly instead of re-fetching via source_url.
-        image_data: Option<Vec<u8>>,
+        image_data: Option<Arc<[u8]>>,
     },
 }
 

--- a/src/core/middleware.rs
+++ b/src/core/middleware.rs
@@ -133,6 +133,9 @@ pub fn instantiate_middleware_from_config(
                 dest_service_id,
                 dest_room_id,
                 prefix_tag,
+                thumbnail_max_width,
+                thumbnail_max_height,
+                thumbnail_jpeg_quality,
             } => Arc::new(ChatRelay::new(
                 make_ctx()?,
                 ChatRelayConfig {
@@ -141,6 +144,9 @@ pub fn instantiate_middleware_from_config(
                     dest_service_id: dest_service_id.clone(),
                     dest_room_id: dest_room_id.clone(),
                     prefix_tag: prefix_tag.clone(),
+                    thumbnail_max_width: *thumbnail_max_width,
+                    thumbnail_max_height: *thumbnail_max_height,
+                    thumbnail_jpeg_quality: *thumbnail_jpeg_quality,
                 },
             )),
             MiddlewareKind::EzStreamAnnounce {

--- a/src/middlewares/chat_relay.rs
+++ b/src/middlewares/chat_relay.rs
@@ -17,6 +17,9 @@ pub struct ChatRelayConfig {
     pub dest_service_id: String,
     pub dest_room_id: String,
     pub prefix_tag: String,
+    pub thumbnail_max_width: u32,
+    pub thumbnail_max_height: u32,
+    pub thumbnail_jpeg_quality: u8,
 }
 
 pub struct ChatRelay {
@@ -26,6 +29,10 @@ pub struct ChatRelay {
     dest_service_id: String,
     dest_room_id: String,
     prefix_tag: String,
+    http_client: reqwest::Client,
+    thumbnail_max_width: u32,
+    thumbnail_max_height: u32,
+    thumbnail_jpeg_quality: u8,
 }
 
 impl ChatRelay {
@@ -37,6 +44,10 @@ impl ChatRelay {
             dest_service_id: config.dest_service_id,
             dest_room_id: config.dest_room_id,
             prefix_tag: config.prefix_tag,
+            http_client: reqwest::Client::new(),
+            thumbnail_max_width: config.thumbnail_max_width,
+            thumbnail_max_height: config.thumbnail_max_height,
+            thumbnail_jpeg_quality: config.thumbnail_jpeg_quality,
         }
     }
 
@@ -48,6 +59,147 @@ impl ChatRelay {
     ) -> String {
         let sender_display = sender_display_name.unwrap_or(sender_id);
         format!("[{}] {}: {}", prefix_tag, sender_display, body)
+    }
+
+    async fn send_text_fallback(
+        cmd_tx: &Sender<Command>,
+        dest_service_id: &ServiceId,
+        dest_room_id: &str,
+        prefix_tag: &str,
+        sender_id: &str,
+        sender_display_name: Option<&str>,
+        body: &str,
+        source_url: &str,
+    ) {
+        let caption = Self::format_relayed_message(prefix_tag, sender_id, sender_display_name, body);
+        let text = format!("{caption} [image: {source_url}]");
+        let command = Command::SendRoomMessage {
+            service_id: dest_service_id.clone(),
+            room_id: dest_room_id.to_string(),
+            body: text.clone(),
+            markdown_body: Some(text),
+            response_tx: None,
+        };
+        if let Err(e) = cmd_tx.send(command).await {
+            error!(error=%e, "failed to send text fallback for image relay");
+        }
+    }
+
+    async fn relay_image(
+        http_client: reqwest::Client,
+        cmd_tx: Sender<Command>,
+        dest_service_id: ServiceId,
+        dest_room_id: String,
+        prefix_tag: String,
+        sender_id: String,
+        sender_display_name: Option<String>,
+        body: String,
+        source_url: String,
+        image_data: Option<Vec<u8>>,
+        thumbnail_max_width: u32,
+        thumbnail_max_height: u32,
+        thumbnail_jpeg_quality: u8,
+    ) {
+        // Use pre-fetched bytes when available (e.g. from an authenticated Matrix client).
+        // Fall back to an HTTP fetch for services that don't pre-fetch.
+        let raw_bytes: Vec<u8> = if let Some(data) = image_data {
+            data
+        } else {
+            let response = match http_client.get(&source_url).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    error!(error=%e, source_url=%source_url, "failed to fetch image for relay");
+                    Self::send_text_fallback(
+                        &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
+                        &sender_id, sender_display_name.as_deref(), &body, &source_url,
+                    ).await;
+                    return;
+                }
+            };
+            match response.error_for_status() {
+                Ok(r) => match r.bytes().await {
+                    Ok(b) => b.to_vec(),
+                    Err(e) => {
+                        error!(error=%e, "failed to read image bytes");
+                        Self::send_text_fallback(
+                            &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
+                            &sender_id, sender_display_name.as_deref(), &body, &source_url,
+                        ).await;
+                        return;
+                    }
+                },
+                Err(e) => {
+                    error!(error=%e, source_url=%source_url, "image fetch returned error status");
+                    Self::send_text_fallback(
+                        &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
+                        &sender_id, sender_display_name.as_deref(), &body, &source_url,
+                    ).await;
+                    return;
+                }
+            }
+        };
+
+        info!(raw_bytes=%raw_bytes.len(), "processing image thumbnail for relay");
+
+        // Decode, resize, and re-encode as JPEG on a blocking thread.
+        // Normalise to Rgb8 before encoding — JpegEncoder can silently produce
+        // empty output when handed an Rgb8 DynamicImage via write_with_encoder,
+        // so we call write_image directly with an explicit color type instead.
+        let thumbnail_result = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<u8>> {
+            use image::{ImageEncoder, ImageReader, codecs::jpeg::JpegEncoder};
+            use std::io::Cursor;
+            let img = ImageReader::new(Cursor::new(&raw_bytes))
+                .with_guessed_format()?
+                .decode()?;
+            let thumb = img.thumbnail(thumbnail_max_width, thumbnail_max_height).into_rgb8();
+            let mut out = Vec::new();
+            JpegEncoder::new_with_quality(&mut out, thumbnail_jpeg_quality).write_image(
+                thumb.as_raw(),
+                thumb.width(),
+                thumb.height(),
+                image::ExtendedColorType::Rgb8,
+            )?;
+            Ok(out)
+        }).await;
+
+        let thumbnail_data = match thumbnail_result {
+            Ok(Ok(data)) => {
+                info!(thumbnail_bytes=%data.len(), "image thumbnail encoded");
+                data
+            }
+            Ok(Err(e)) => {
+                error!(error=%e, "failed to process image thumbnail");
+                Self::send_text_fallback(
+                    &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
+                    &sender_id, sender_display_name.as_deref(), &body, &source_url,
+                ).await;
+                return;
+            }
+            Err(e) => {
+                error!(error=%e, "image processing task panicked");
+                Self::send_text_fallback(
+                    &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
+                    &sender_id, sender_display_name.as_deref(), &body, &source_url,
+                ).await;
+                return;
+            }
+        };
+
+        let sender_display = sender_display_name.as_deref().unwrap_or(&sender_id);
+        let caption = format!("[{prefix_tag}] {sender_display}:");
+
+        let command = Command::SendRoomImage {
+            service_id: dest_service_id,
+            room_id: dest_room_id,
+            caption,
+            source_url,
+            thumbnail_data,
+            thumbnail_mimetype: "image/jpeg".to_string(),
+        };
+
+        if let Err(e) = cmd_tx.send(command).await {
+            error!(error=%e, "failed to send SendRoomImage command");
+        }
     }
 }
 
@@ -73,57 +225,99 @@ impl Middleware for ChatRelay {
             return Ok(Verdict::Continue);
         }
 
-        // Filter: only handle RoomMessage events
-        let EventKind::RoomMessage {
-            room_id, body, sender_id, sender_display_name, is_self, ..
-        } = &event.kind
-        else {
-            return Ok(Verdict::Continue);
-        };
+        match &event.kind {
+            EventKind::RoomMessage { room_id, body, sender_id, sender_display_name, is_self, .. } => {
+                if let Some(ref expected_room) = self.source_room_id
+                    && room_id != expected_room
+                {
+                    return Ok(Verdict::Continue);
+                }
+                if *is_self {
+                    debug!("ignoring message from bot itself");
+                    return Ok(Verdict::Continue);
+                }
 
-        // Filter: check source room if specified
-        if let Some(ref expected_room) = self.source_room_id
-            && room_id != expected_room
-        {
-            return Ok(Verdict::Continue);
-        }
-
-        // Filter: ignore messages from the bot itself
-        if *is_self {
-            debug!("ignoring message from bot itself");
-            return Ok(Verdict::Continue);
-        }
-
-        // Format and relay the message
-        let formatted_body = Self::format_relayed_message(
-            &self.prefix_tag,
-            sender_id,
-            sender_display_name.as_deref(),
-            body,
-        );
-
-        let cmd_tx = self.cmd_tx.clone();
-        let dest_service_id = ServiceId(self.dest_service_id.clone());
-        let dest_room_id = self.dest_room_id.clone();
-
-        tokio::spawn(async move {
-            let command = Command::SendRoomMessage {
-                service_id: dest_service_id.clone(),
-                room_id: dest_room_id.clone(),
-                body: formatted_body.clone(),
-                markdown_body: Some(formatted_body),
-                response_tx: None,
-            };
-
-            if let Err(e) = cmd_tx.send(command).await {
-                error!(
-                    dest_service=%dest_service_id.0,
-                    dest_room=%dest_room_id,
-                    error=%e,
-                    "failed to send chat relay command"
+                let formatted_body = Self::format_relayed_message(
+                    &self.prefix_tag,
+                    sender_id,
+                    sender_display_name.as_deref(),
+                    body,
                 );
+
+                let cmd_tx = self.cmd_tx.clone();
+                let dest_service_id = ServiceId(self.dest_service_id.clone());
+                let dest_room_id = self.dest_room_id.clone();
+
+                tokio::spawn(async move {
+                    let command = Command::SendRoomMessage {
+                        service_id: dest_service_id.clone(),
+                        room_id: dest_room_id.clone(),
+                        body: formatted_body.clone(),
+                        markdown_body: Some(formatted_body),
+                        response_tx: None,
+                    };
+                    if let Err(e) = cmd_tx.send(command).await {
+                        error!(
+                            dest_service=%dest_service_id.0,
+                            dest_room=%dest_room_id,
+                            error=%e,
+                            "failed to send chat relay command"
+                        );
+                    }
+                });
             }
-        });
+            EventKind::RoomImage {
+                room_id,
+                sender_id,
+                sender_display_name,
+                is_self,
+                body,
+                source_url,
+                image_data,
+                ..
+            } => {
+                if let Some(ref expected_room) = self.source_room_id
+                    && room_id != expected_room
+                {
+                    return Ok(Verdict::Continue);
+                }
+                if *is_self {
+                    debug!("ignoring image from bot itself");
+                    return Ok(Verdict::Continue);
+                }
+
+                let http_client = self.http_client.clone();
+                let cmd_tx = self.cmd_tx.clone();
+                let dest_service_id = ServiceId(self.dest_service_id.clone());
+                let dest_room_id = self.dest_room_id.clone();
+                let prefix_tag = self.prefix_tag.clone();
+                let sender_id = sender_id.clone();
+                let sender_display_name = sender_display_name.clone();
+                let body = body.clone();
+                let source_url = source_url.clone();
+                let image_data = image_data.clone();
+                let thumbnail_max_width = self.thumbnail_max_width;
+                let thumbnail_max_height = self.thumbnail_max_height;
+                let thumbnail_jpeg_quality = self.thumbnail_jpeg_quality;
+
+                tokio::spawn(Self::relay_image(
+                    http_client,
+                    cmd_tx,
+                    dest_service_id,
+                    dest_room_id,
+                    prefix_tag,
+                    sender_id,
+                    sender_display_name,
+                    body,
+                    source_url,
+                    image_data,
+                    thumbnail_max_width,
+                    thumbnail_max_height,
+                    thumbnail_jpeg_quality,
+                ));
+            }
+            _ => {}
+        }
 
         Ok(Verdict::Continue)
     }

--- a/src/middlewares/chat_relay.rs
+++ b/src/middlewares/chat_relay.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
@@ -95,14 +97,14 @@ impl ChatRelay {
         sender_display_name: Option<String>,
         body: String,
         source_url: String,
-        image_data: Option<Vec<u8>>,
+        image_data: Option<Arc<[u8]>>,
         thumbnail_max_width: u32,
         thumbnail_max_height: u32,
         thumbnail_jpeg_quality: u8,
     ) {
         // Use pre-fetched bytes when available (e.g. from an authenticated Matrix client).
         // Fall back to an HTTP fetch for services that don't pre-fetch.
-        let raw_bytes: Vec<u8> = if let Some(data) = image_data {
+        let raw_bytes: Arc<[u8]> = if let Some(data) = image_data {
             data
         } else {
             let response = match http_client.get(&source_url).send().await {
@@ -118,7 +120,7 @@ impl ChatRelay {
             };
             match response.error_for_status() {
                 Ok(r) => match r.bytes().await {
-                    Ok(b) => b.to_vec(),
+                    Ok(b) => Arc::from(b.as_ref()),
                     Err(e) => {
                         error!(error=%e, "failed to read image bytes");
                         Self::send_text_fallback(
@@ -273,7 +275,7 @@ impl Middleware for ChatRelay {
                 is_self,
                 body,
                 source_url,
-                image_data,
+                image_data, // Option<Arc<[u8]>> — clone is one atomic increment
                 ..
             } => {
                 if let Some(ref expected_room) = self.source_room_id

--- a/src/middlewares/chat_relay.rs
+++ b/src/middlewares/chat_relay.rs
@@ -63,6 +63,7 @@ impl ChatRelay {
         format!("[{}] {}: {}", prefix_tag, sender_display, body)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn send_text_fallback(
         cmd_tx: &Sender<Command>,
         dest_service_id: &ServiceId,
@@ -73,7 +74,8 @@ impl ChatRelay {
         body: &str,
         source_url: &str,
     ) {
-        let caption = Self::format_relayed_message(prefix_tag, sender_id, sender_display_name, body);
+        let caption =
+            Self::format_relayed_message(prefix_tag, sender_id, sender_display_name, body);
         let text = format!("{caption} [image: {source_url}]");
         let command = Command::SendRoomMessage {
             service_id: dest_service_id.clone(),
@@ -87,6 +89,7 @@ impl ChatRelay {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn relay_image(
         http_client: reqwest::Client,
         cmd_tx: Sender<Command>,
@@ -112,9 +115,16 @@ impl ChatRelay {
                 Err(e) => {
                     error!(error=%e, source_url=%source_url, "failed to fetch image for relay");
                     Self::send_text_fallback(
-                        &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
-                        &sender_id, sender_display_name.as_deref(), &body, &source_url,
-                    ).await;
+                        &cmd_tx,
+                        &dest_service_id,
+                        &dest_room_id,
+                        &prefix_tag,
+                        &sender_id,
+                        sender_display_name.as_deref(),
+                        &body,
+                        &source_url,
+                    )
+                    .await;
                     return;
                 }
             };
@@ -124,18 +134,32 @@ impl ChatRelay {
                     Err(e) => {
                         error!(error=%e, "failed to read image bytes");
                         Self::send_text_fallback(
-                            &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
-                            &sender_id, sender_display_name.as_deref(), &body, &source_url,
-                        ).await;
+                            &cmd_tx,
+                            &dest_service_id,
+                            &dest_room_id,
+                            &prefix_tag,
+                            &sender_id,
+                            sender_display_name.as_deref(),
+                            &body,
+                            &source_url,
+                        )
+                        .await;
                         return;
                     }
                 },
                 Err(e) => {
                     error!(error=%e, source_url=%source_url, "image fetch returned error status");
                     Self::send_text_fallback(
-                        &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
-                        &sender_id, sender_display_name.as_deref(), &body, &source_url,
-                    ).await;
+                        &cmd_tx,
+                        &dest_service_id,
+                        &dest_room_id,
+                        &prefix_tag,
+                        &sender_id,
+                        sender_display_name.as_deref(),
+                        &body,
+                        &source_url,
+                    )
+                    .await;
                     return;
                 }
             }
@@ -150,9 +174,7 @@ impl ChatRelay {
         let thumbnail_result = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<u8>> {
             use image::{ImageEncoder, ImageReader, codecs::jpeg::JpegEncoder};
             use std::io::Cursor;
-            let img = ImageReader::new(Cursor::new(&raw_bytes))
-                .with_guessed_format()?
-                .decode()?;
+            let img = ImageReader::new(Cursor::new(&raw_bytes)).with_guessed_format()?.decode()?;
             let thumb = img.thumbnail(thumbnail_max_width, thumbnail_max_height).into_rgb8();
             let mut out = Vec::new();
             JpegEncoder::new_with_quality(&mut out, thumbnail_jpeg_quality).write_image(
@@ -162,7 +184,8 @@ impl ChatRelay {
                 image::ExtendedColorType::Rgb8,
             )?;
             Ok(out)
-        }).await;
+        })
+        .await;
 
         let thumbnail_data = match thumbnail_result {
             Ok(Ok(data)) => {
@@ -172,17 +195,31 @@ impl ChatRelay {
             Ok(Err(e)) => {
                 error!(error=%e, "failed to process image thumbnail");
                 Self::send_text_fallback(
-                    &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
-                    &sender_id, sender_display_name.as_deref(), &body, &source_url,
-                ).await;
+                    &cmd_tx,
+                    &dest_service_id,
+                    &dest_room_id,
+                    &prefix_tag,
+                    &sender_id,
+                    sender_display_name.as_deref(),
+                    &body,
+                    &source_url,
+                )
+                .await;
                 return;
             }
             Err(e) => {
                 error!(error=%e, "image processing task panicked");
                 Self::send_text_fallback(
-                    &cmd_tx, &dest_service_id, &dest_room_id, &prefix_tag,
-                    &sender_id, sender_display_name.as_deref(), &body, &source_url,
-                ).await;
+                    &cmd_tx,
+                    &dest_service_id,
+                    &dest_room_id,
+                    &prefix_tag,
+                    &sender_id,
+                    sender_display_name.as_deref(),
+                    &body,
+                    &source_url,
+                )
+                .await;
                 return;
             }
         };
@@ -228,7 +265,14 @@ impl Middleware for ChatRelay {
         }
 
         match &event.kind {
-            EventKind::RoomMessage { room_id, body, sender_id, sender_display_name, is_self, .. } => {
+            EventKind::RoomMessage {
+                room_id,
+                body,
+                sender_id,
+                sender_display_name,
+                is_self,
+                ..
+            } => {
                 if let Some(ref expected_room) = self.source_room_id
                     && room_id != expected_room
                 {

--- a/src/middlewares/echo.rs
+++ b/src/middlewares/echo.rs
@@ -35,7 +35,8 @@ impl Middleware for Echo {
             EventKind::RoomMessage { body, is_self, .. } => (body, *is_self),
             EventKind::UserListUpdate { .. }
             | EventKind::ReactionAdded { .. }
-            | EventKind::ReactionRemoved { .. } => return Ok(Verdict::Continue),
+            | EventKind::ReactionRemoved { .. }
+            | EventKind::RoomImage { .. } => return Ok(Verdict::Continue),
         };
 
         // Ignore messages from self to prevent infinite recursion
@@ -66,7 +67,8 @@ impl Middleware for Echo {
                 },
                 EventKind::UserListUpdate { .. }
                 | EventKind::ReactionAdded { .. }
-                | EventKind::ReactionRemoved { .. } => unreachable!(),
+                | EventKind::ReactionRemoved { .. }
+                | EventKind::RoomImage { .. } => unreachable!(),
             };
 
             // Send the command and wait for the message ID

--- a/src/middlewares/invite.rs
+++ b/src/middlewares/invite.rs
@@ -41,7 +41,8 @@ impl Middleware for Invite {
             EventKind::UserListUpdate { .. }
             | EventKind::RoomMessage { .. }
             | EventKind::ReactionAdded { .. }
-            | EventKind::ReactionRemoved { .. } => {
+            | EventKind::ReactionRemoved { .. }
+            | EventKind::RoomImage { .. } => {
                 // Ignore non-DM events
                 return Ok(Verdict::Continue);
             }

--- a/src/services/dummy.rs
+++ b/src/services/dummy.rs
@@ -81,6 +81,9 @@ impl Service for DummyService {
                 info!(service=%self.id, room_id=%room_id, event_id=%event_id, key=%key,
                       "dummy service: would add reaction");
             }
+            Command::SendRoomImage { room_id, caption, .. } => {
+                info!(service=%self.id, room_id=%room_id, caption=%caption, "dummy service: would send room image");
+            }
         }
         Ok(())
     }

--- a/src/services/matrix.rs
+++ b/src/services/matrix.rs
@@ -499,7 +499,7 @@ impl MatrixService {
                                 format: MediaFormat::File,
                             };
                             let image_data = match _client.media().get_media_content(&request, false).await {
-                                Ok(bytes) => Some(bytes),
+                                Ok(bytes) => Some(Arc::from(bytes)),
                                 Err(e) => {
                                     warn!(error=%e, "failed to fetch image content for relay");
                                     None

--- a/src/services/matrix.rs
+++ b/src/services/matrix.rs
@@ -12,8 +12,8 @@ use matrix_sdk::{
             room::{
                 member::{MembershipState, StrippedRoomMemberEvent, SyncRoomMemberEvent},
                 message::{
-                    MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
-                    TextMessageEventContent,
+                    MessageType, OriginalSyncRoomMessageEvent,
+                    RoomMessageEventContent, TextMessageEventContent,
                 },
                 redaction::OriginalSyncRoomRedactionEvent,
             },
@@ -32,6 +32,7 @@ use crate::core::{
     event::{Event, EventKind},
     service::{Service, ServiceId},
 };
+
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MatrixUserId(pub String);
@@ -421,14 +422,14 @@ impl MatrixService {
         let bot_user_id_for_handler =
             self.client.user_id().expect("client should have user_id after login").to_owned();
         self.client.add_event_handler(
-            |event: OriginalSyncRoomMessageEvent, room: Room, _client: Client| async move {
+            move |event: OriginalSyncRoomMessageEvent, room: Room, _client: Client| {
+                let service_id = service_id.clone();
+                let evt_tx = evt_tx.clone();
+                let bot_user_id_for_handler = bot_user_id_for_handler.clone();
+                async move {
                 if room.state() != RoomState::Joined {
                     return;
                 }
-
-                let MessageType::Text(text_content) = event.content.msgtype else {
-                    return;
-                };
 
                 let Ok(is_direct) = room.is_direct().await else {
                     warn!("could not determine if message was a direct message");
@@ -450,39 +451,80 @@ impl MatrixService {
                 let sender_id = event.sender.to_string();
                 let is_self = event.sender == bot_user_id_for_handler;
 
-                match is_direct {
-                    true => {
-                        let event = Event {
-                            service_id,
-                            kind: EventKind::DirectMessage {
-                                user_id: sender_id.clone(),
-                                body: text_content.body,
-                                is_local_user,
-                                sender_id,
-                                sender_display_name: sender_display_name.clone(),
-                                is_self,
-                            },
-                        };
+                match event.content.msgtype {
+                    MessageType::Text(text_content) => match is_direct {
+                        true => {
+                            let event = Event {
+                                service_id,
+                                kind: EventKind::DirectMessage {
+                                    user_id: sender_id.clone(),
+                                    body: text_content.body,
+                                    is_local_user,
+                                    sender_id,
+                                    sender_display_name: sender_display_name.clone(),
+                                    is_self,
+                                },
+                            };
+                            let _ = evt_tx.send(event).await;
+                        }
+                        false => {
+                            let event = Event {
+                                service_id,
+                                kind: EventKind::RoomMessage {
+                                    room_id: room.room_id().to_string(),
+                                    body: text_content.body,
+                                    is_local_user,
+                                    sender_id,
+                                    sender_display_name,
+                                    is_self,
+                                },
+                            };
+                            let _ = evt_tx.send(event).await;
+                        }
+                    },
+                    MessageType::Image(image_content) => {
+                        if is_direct {
+                            return; // only relay room images, not DM images
+                        }
+                        let mimetype = image_content.info.as_ref().and_then(|i| i.mimetype.clone());
+                        let room_id = room.room_id().to_string();
+                        let source_url = format!("https://matrix.to/#/{}/{}", room_id, event.event_id);
 
-                        let _ = evt_tx.send(event).await;
+                        // Fetch image bytes using the authenticated SDK client.
+                        // Spawned so the event handler returns promptly.
+                        tokio::spawn(async move {
+                            use matrix_sdk::media::{MediaFormat, MediaRequestParameters};
+                            let request = MediaRequestParameters {
+                                source: image_content.source.clone(),
+                                format: MediaFormat::File,
+                            };
+                            let image_data = match _client.media().get_media_content(&request, false).await {
+                                Ok(bytes) => Some(bytes),
+                                Err(e) => {
+                                    warn!(error=%e, "failed to fetch image content for relay");
+                                    None
+                                }
+                            };
+                            let event = Event {
+                                service_id,
+                                kind: EventKind::RoomImage {
+                                    room_id,
+                                    sender_id,
+                                    sender_display_name,
+                                    is_self,
+                                    is_local_user,
+                                    body: image_content.body,
+                                    source_url,
+                                    mimetype,
+                                    image_data,
+                                },
+                            };
+                            let _ = evt_tx.send(event).await;
+                        });
                     }
-                    false => {
-                        let event = Event {
-                            service_id,
-                            kind: EventKind::RoomMessage {
-                                room_id: room.room_id().to_string(),
-                                body: text_content.body,
-                                is_local_user,
-                                sender_id,
-                                sender_display_name,
-                                is_self,
-                            },
-                        };
-
-                        let _ = evt_tx.send(event).await;
-                    }
+                    _ => {} // ignore other message types
                 }
-            },
+            }},
         );
 
         // Handle reactions
@@ -903,6 +945,9 @@ impl Service for MatrixService {
                 // Send response back through oneshot channel
                 // Ignore send errors (receiver may have been dropped)
                 let _ = response_tx.send(result);
+            }
+            Command::SendRoomImage { .. } => {
+                warn!(service=%self.id, "SendRoomImage not implemented for Matrix service");
             }
             Command::AddReaction { room_id, event_id, key, .. } => {
                 info!(service=%self.id, room_id=%room_id, event_id=%event_id, key=%key, "adding reaction");

--- a/src/services/matrix.rs
+++ b/src/services/matrix.rs
@@ -12,8 +12,8 @@ use matrix_sdk::{
             room::{
                 member::{MembershipState, StrippedRoomMemberEvent, SyncRoomMemberEvent},
                 message::{
-                    MessageType, OriginalSyncRoomMessageEvent,
-                    RoomMessageEventContent, TextMessageEventContent,
+                    MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
+                    TextMessageEventContent,
                 },
                 redaction::OriginalSyncRoomRedactionEvent,
             },
@@ -32,7 +32,6 @@ use crate::core::{
     event::{Event, EventKind},
     service::{Service, ServiceId},
 };
-
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MatrixUserId(pub String);
@@ -427,104 +426,111 @@ impl MatrixService {
                 let evt_tx = evt_tx.clone();
                 let bot_user_id_for_handler = bot_user_id_for_handler.clone();
                 async move {
-                if room.state() != RoomState::Joined {
-                    return;
-                }
-
-                let Ok(is_direct) = room.is_direct().await else {
-                    warn!("could not determine if message was a direct message");
-                    return;
-                };
-
-                // Check if user is from the same homeserver as the bot
-                let is_local_user =
-                    event.sender.server_name() == bot_user_id_for_handler.server_name();
-
-                // Get sender display name
-                let sender_display_name = room
-                    .get_member(&event.sender)
-                    .await
-                    .ok()
-                    .and_then(|m| m)
-                    .and_then(|m| m.display_name().map(|s| s.to_string()));
-
-                let sender_id = event.sender.to_string();
-                let is_self = event.sender == bot_user_id_for_handler;
-
-                match event.content.msgtype {
-                    MessageType::Text(text_content) => match is_direct {
-                        true => {
-                            let event = Event {
-                                service_id,
-                                kind: EventKind::DirectMessage {
-                                    user_id: sender_id.clone(),
-                                    body: text_content.body,
-                                    is_local_user,
-                                    sender_id,
-                                    sender_display_name: sender_display_name.clone(),
-                                    is_self,
-                                },
-                            };
-                            let _ = evt_tx.send(event).await;
-                        }
-                        false => {
-                            let event = Event {
-                                service_id,
-                                kind: EventKind::RoomMessage {
-                                    room_id: room.room_id().to_string(),
-                                    body: text_content.body,
-                                    is_local_user,
-                                    sender_id,
-                                    sender_display_name,
-                                    is_self,
-                                },
-                            };
-                            let _ = evt_tx.send(event).await;
-                        }
-                    },
-                    MessageType::Image(image_content) => {
-                        if is_direct {
-                            return; // only relay room images, not DM images
-                        }
-                        let mimetype = image_content.info.as_ref().and_then(|i| i.mimetype.clone());
-                        let room_id = room.room_id().to_string();
-                        let source_url = format!("https://matrix.to/#/{}/{}", room_id, event.event_id);
-
-                        // Fetch image bytes using the authenticated SDK client.
-                        // Spawned so the event handler returns promptly.
-                        tokio::spawn(async move {
-                            use matrix_sdk::media::{MediaFormat, MediaRequestParameters};
-                            let request = MediaRequestParameters {
-                                source: image_content.source.clone(),
-                                format: MediaFormat::File,
-                            };
-                            let image_data = match _client.media().get_media_content(&request, false).await {
-                                Ok(bytes) => Some(Arc::from(bytes)),
-                                Err(e) => {
-                                    warn!(error=%e, "failed to fetch image content for relay");
-                                    None
-                                }
-                            };
-                            let event = Event {
-                                service_id,
-                                kind: EventKind::RoomImage {
-                                    room_id,
-                                    sender_id,
-                                    sender_display_name,
-                                    is_self,
-                                    is_local_user,
-                                    body: image_content.body,
-                                    source_url,
-                                    mimetype,
-                                    image_data,
-                                },
-                            };
-                            let _ = evt_tx.send(event).await;
-                        });
+                    if room.state() != RoomState::Joined {
+                        return;
                     }
-                    _ => {} // ignore other message types
+
+                    let Ok(is_direct) = room.is_direct().await else {
+                        warn!("could not determine if message was a direct message");
+                        return;
+                    };
+
+                    // Check if user is from the same homeserver as the bot
+                    let is_local_user =
+                        event.sender.server_name() == bot_user_id_for_handler.server_name();
+
+                    // Get sender display name
+                    let sender_display_name = room
+                        .get_member(&event.sender)
+                        .await
+                        .ok()
+                        .and_then(|m| m)
+                        .and_then(|m| m.display_name().map(|s| s.to_string()));
+
+                    let sender_id = event.sender.to_string();
+                    let is_self = event.sender == bot_user_id_for_handler;
+
+                    match event.content.msgtype {
+                        MessageType::Text(text_content) => match is_direct {
+                            true => {
+                                let event = Event {
+                                    service_id,
+                                    kind: EventKind::DirectMessage {
+                                        user_id: sender_id.clone(),
+                                        body: text_content.body,
+                                        is_local_user,
+                                        sender_id,
+                                        sender_display_name: sender_display_name.clone(),
+                                        is_self,
+                                    },
+                                };
+                                let _ = evt_tx.send(event).await;
+                            }
+                            false => {
+                                let event = Event {
+                                    service_id,
+                                    kind: EventKind::RoomMessage {
+                                        room_id: room.room_id().to_string(),
+                                        body: text_content.body,
+                                        is_local_user,
+                                        sender_id,
+                                        sender_display_name,
+                                        is_self,
+                                    },
+                                };
+                                let _ = evt_tx.send(event).await;
+                            }
+                        },
+                        MessageType::Image(image_content) => {
+                            if is_direct {
+                                return; // only relay room images, not DM images
+                            }
+                            let mimetype =
+                                image_content.info.as_ref().and_then(|i| i.mimetype.clone());
+                            let room_id = room.room_id().to_string();
+                            let source_url =
+                                format!("https://matrix.to/#/{}/{}", room_id, event.event_id);
+
+                            // Fetch image bytes using the authenticated SDK client.
+                            // Spawned so the event handler returns promptly.
+                            tokio::spawn(async move {
+                                use matrix_sdk::media::{MediaFormat, MediaRequestParameters};
+                                let request = MediaRequestParameters {
+                                    source: image_content.source.clone(),
+                                    format: MediaFormat::File,
+                                };
+                                let image_data = match _client
+                                    .media()
+                                    .get_media_content(&request, false)
+                                    .await
+                                {
+                                    Ok(bytes) => Some(Arc::from(bytes)),
+                                    Err(e) => {
+                                        warn!(error=%e, "failed to fetch image content for relay");
+                                        None
+                                    }
+                                };
+                                let event = Event {
+                                    service_id,
+                                    kind: EventKind::RoomImage {
+                                        room_id,
+                                        sender_id,
+                                        sender_display_name,
+                                        is_self,
+                                        is_local_user,
+                                        body: image_content.body,
+                                        source_url,
+                                        mimetype,
+                                        image_data,
+                                    },
+                                };
+                                let _ = evt_tx.send(event).await;
+                            });
+                        }
+                        _ => {} // ignore other message types
+                    }
                 }
-            }},
+            },
         );
 
         // Handle reactions

--- a/src/services/mumble.rs
+++ b/src/services/mumble.rs
@@ -511,6 +511,44 @@ impl Service for MumbleService {
             Command::AddReaction { .. } => {
                 warn!("mumble does not support reactions");
             }
+            Command::SendRoomImage {
+                room_id,
+                caption,
+                source_url,
+                thumbnail_data,
+                thumbnail_mimetype,
+                ..
+            } => {
+                debug!(room_id=%room_id, "sending image to mumble channel");
+
+                let state = self.state.lock().await;
+                let result = match state.channel_ids.get(&room_id) {
+                    Some(channel_id) => {
+                        use base64::Engine as _;
+                        let encoded =
+                            base64::engine::general_purpose::STANDARD.encode(&thumbnail_data);
+                        let html = format!(
+                            "{caption}<br/>\
+                             <img src=\"data:{thumbnail_mimetype};base64,{encoded}\"/><br/>\
+                             <a href=\"{source_url}\">View full image</a>"
+                        );
+
+                        let mut msg = TextMessage::new();
+                        msg.set_message(html);
+                        msg.channel_id = vec![*channel_id];
+
+                        match tx.send(ControlPacket::TextMessage(Box::new(msg))).await {
+                            Ok(_) => Ok(String::new()),
+                            Err(e) => Err(anyhow!("failed to send image message: {}", e)),
+                        }
+                    }
+                    None => Err(anyhow!("unknown channel: {}", room_id)),
+                };
+
+                if let Err(e) = result {
+                    error!(error=%e, room_id=%room_id, "failed to relay image to mumble");
+                }
+            }
         }
 
         Ok(())

--- a/tests/unit/middleware.rs
+++ b/tests/unit/middleware.rs
@@ -506,6 +506,9 @@ async fn test_chat_relay_middleware_run() {
             dest_service_id: "dest".to_string(),
             dest_room_id: "!dest:example.com".to_string(),
             prefix_tag: "Test".to_string(),
+            thumbnail_max_width: 200,
+            thumbnail_max_height: 150,
+            thumbnail_jpeg_quality: 60,
         },
     );
     let cancel_token = CancellationToken::new();
@@ -527,6 +530,9 @@ async fn test_chat_relay_forwards_message_with_correct_format() {
             dest_service_id: "matrix".to_string(),
             dest_room_id: "!voice:matrix.org".to_string(),
             prefix_tag: "Mumble".to_string(),
+            thumbnail_max_width: 200,
+            thumbnail_max_height: 150,
+            thumbnail_jpeg_quality: 60,
         },
     );
 
@@ -573,6 +579,9 @@ async fn test_chat_relay_filters_bot_messages() {
             dest_service_id: "matrix".to_string(),
             dest_room_id: "!voice:matrix.org".to_string(),
             prefix_tag: "Mumble".to_string(),
+            thumbnail_max_width: 200,
+            thumbnail_max_height: 150,
+            thumbnail_jpeg_quality: 60,
         },
     );
 
@@ -609,6 +618,9 @@ async fn test_chat_relay_ignores_wrong_service() {
             dest_service_id: "matrix".to_string(),
             dest_room_id: "!voice:matrix.org".to_string(),
             prefix_tag: "Mumble".to_string(),
+            thumbnail_max_width: 200,
+            thumbnail_max_height: 150,
+            thumbnail_jpeg_quality: 60,
         },
     );
 
@@ -644,6 +656,9 @@ async fn test_chat_relay_filters_by_source_room() {
             dest_service_id: "matrix".to_string(),
             dest_room_id: "!announcements:matrix.org".to_string(),
             prefix_tag: "General".to_string(),
+            thumbnail_max_width: 200,
+            thumbnail_max_height: 150,
+            thumbnail_jpeg_quality: 60,
         },
     );
 
@@ -707,6 +722,9 @@ async fn test_chat_relay_ignores_direct_messages() {
             dest_service_id: "matrix".to_string(),
             dest_room_id: "!voice:matrix.org".to_string(),
             prefix_tag: "Mumble".to_string(),
+            thumbnail_max_width: 200,
+            thumbnail_max_height: 150,
+            thumbnail_jpeg_quality: 60,
         },
     );
 
@@ -742,6 +760,9 @@ async fn test_chat_relay_handles_missing_display_name() {
             dest_service_id: "matrix".to_string(),
             dest_room_id: "!voice:matrix.org".to_string(),
             prefix_tag: "Mumble".to_string(),
+            thumbnail_max_width: 200,
+            thumbnail_max_height: 150,
+            thumbnail_jpeg_quality: 60,
         },
     );
 
@@ -787,6 +808,9 @@ async fn test_chat_relay_instantiation_from_config() {
                 dest_service_id: "matrix_main".to_string(),
                 dest_room_id: "!voice:matrix.org".to_string(),
                 prefix_tag: "Mumble".to_string(),
+                thumbnail_max_width: 200,
+                thumbnail_max_height: 150,
+                thumbnail_jpeg_quality: 60,
             },
         },
     );


### PR DESCRIPTION
Adds image cross-posting support to the chat_relay middleware. When an image is posted in a Matrix room, the bot fetches it using the authenticated Matrix SDK client (required for servers with Matrix v1.11 authenticated media enabled), resizes and re-encodes it as a JPEG thumbnail, and sends it to the configured Mumble channel as an HTML message with a base64-embedded preview and a matrix.to link back to the original event.

New abstractions:
- EventKind::RoomImage — service-agnostic image event carrying sender metadata, a source link, optional mimetype, and pre-fetched image bytes
- Command::SendRoomImage — carries a pre-processed JPEG thumbnail and caption for delivery to any destination service

Thumbnail defaults (configurable per relay via chat_relay config):
- 480×360 px, JPEG quality 75